### PR TITLE
Use official amqp library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## 0.0.1-dev.2
+
+* Switch back amqp library to the official version that supports OTP 19
+
+We are still discussing backward incompatible changes. Please see [Gihub issues](https://github.com/shinyscorpion/task_bunny/issues) for the details.
+
 ## 0.0.1-dev.1
 
 * Preparing the first official release
 
-We are still discussing backward incompatible changes. Please see [Gihub issues](https://github.com/shinyscorpion/task_bunny/issues) for the details.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ TaskBunny heavily relies on [amqp](https://github.com/pma/amqp) by Paulo Almeida
   1. Add `task_bunny` to your list of dependencies in `mix.exs`:
 
         def deps do
-          [{:task_bunny, "~> 0.0.1-dev.1"}]
+          [{:task_bunny, "~> 0.0.1-dev.2"}]
         end
 
   1. Start `task_bunny` before your application (required Elixir 1.3 and before):

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule TaskBunny.Mixfile do
   use Mix.Project
-  @version "0.0.1-dev.1"
+  @version "0.0.1-dev.2"
 
   def project do
     [

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule TaskBunny.Mixfile do
   defp deps do
     [
       {:poison, "~> 2.0"},
-      {:ono_amqp, "~> 0.2.0-pre.1"},
+      {:amqp, "~> 0.2.0-pre.1"},
       {:meck, "~> 0.8.2", only: :test},
       {:logger_file_backend, "~> 0.0.9", only: :test},
       {:ex_doc, "~> 0.14", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,5 @@
-%{"amqp_client": {:hex, :amqp_client, "3.6.7-pre.1", "5d689656443cf652a0114806e7e2f5c63ceac4d768382ffa08570a246f0e8eaf", [:make, :rebar3], [{:rabbit_common, "3.6.7-pre.1", [hex: :rabbit_common, optional: false]}]},
+%{"amqp": {:hex, :amqp, "0.2.0-pre.1", "55b7755ea840ee0beb194f891736323ef7059e8beda2c240ee07730338157114", [:mix], [{:amqp_client, "~> 3.6.7-pre.1", [hex: :amqp_client, optional: false]}]},
+  "amqp_client": {:hex, :amqp_client, "3.6.7-pre.1", "5d689656443cf652a0114806e7e2f5c63ceac4d768382ffa08570a246f0e8eaf", [:make, :rebar3], [{:rabbit_common, "3.6.7-pre.1", [hex: :rabbit_common, optional: false]}]},
   "earmark": {:hex, :earmark, "1.1.0", "8c2bf85d725050a92042bc1edf362621004d43ca6241c756f39612084e95487f", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "logger_file_backend": {:hex, :logger_file_backend, "0.0.9", "5c2f7d4a28431e695cdf94d191523dbafe609321a67bb654254897f546c393db", [:mix], []},


### PR DESCRIPTION
Since https://github.com/pma/amqp/pull/51 was merged, we can use official amqp library.