### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,7 @@ elixir:
   - 1.4.1
 otp_release:
   - 19.2
+after_script:
+  - mix inch.report
 services:
   - rabbitmq

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ after_script:
   - mix inch.report
 services:
   - rabbitmq
+cache:
+  directories:
+    - _build
+    - deps

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 sudo: true
 language: elixir
 elixir:
-  - 1.3.4
   - 1.4.1
 otp_release:
   - 19.2
-after_script:
-  - mix deps.get --only docs
-  - MIX_ENV=docs mix inch.report
 services:
   - rabbitmq

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TaskBunny
+# TaskBunny [![Build Status](https://travis-ci.org/shinyscorpion/task_bunny.svg?branch=master)](https://travis-ci.org/shinyscorpion/task_bunny)
 
 [![Hex.pm](https://img.shields.io/hexpm/v/task_bunny.svg "Hex")](https://hex.pm/packages/task_bunny)
 [![Build Status](https://travis-ci.org/shinyscorpion/task_bunny.svg?branch=master)](https://travis-ci.org/shinyscorpion/task_bunny)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TaskBunny [![Build Status](https://travis-ci.org/shinyscorpion/task_bunny.svg?branch=master)](https://travis-ci.org/shinyscorpion/task_bunny)
+# TaskBunny
 
 [![Hex.pm](https://img.shields.io/hexpm/v/task_bunny.svg "Hex")](https://hex.pm/packages/task_bunny)
 [![Build Status](https://travis-ci.org/shinyscorpion/task_bunny.svg?branch=master)](https://travis-ci.org/shinyscorpion/task_bunny)

--- a/mix.exs
+++ b/mix.exs
@@ -71,7 +71,7 @@ defmodule TaskBunny.Mixfile do
       {:inch_ex, "~> 0.5", only: [:dev, :test]},
       {:logger_file_backend, "~> 0.0.9", only: :test},
       {:meck, "~> 0.8.2", only: :test},
-      {:poison, "~> 2.0"},
+      {:poison, "~> 2.0 or ~> 3.0"},
     ]
   end
 end

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -36,7 +36,7 @@ defmodule TaskBunny.TestSupport.JobTestHelper do
       end
     end || false
 
-    :timer.sleep(5) # wait for the last message handled
+    :timer.sleep(20) # wait for the last message handled
     performed
   end
 

--- a/test/task_bunny/message_test.exs
+++ b/test/task_bunny/message_test.exs
@@ -1,0 +1,20 @@
+defmodule TaskBunny.MessageTest do
+  use ExUnit.Case, async: true
+  alias TaskBunny.Message
+
+  describe "failed_count" do
+    test "RabbitMQ 3.6 header" do
+      meta = %{app_id: :undefined, cluster_id: :undefined, consumer_tag: "amq.ctag-6gbrfVhVEsg5UluIEagNcQ", content_encoding: :undefined, content_type: :undefined, correlation_id: :undefined, delivery_tag: 69, exchange: "", expiration: :undefined, headers: [{"x-death", :array, [table: [{"count", :long, 67}, {"exchange", :longstr, ""}, {"queue", :longstr, "dlx.retry"}, {"reason", :longstr, "expired"}, {"routing-keys", :array, [longstr: "dlx.retry"]}, {"time", :timestamp, 1484651945}], table: [{"count", :long, 67}, {"exchange", :longstr, ""},{"queue", :longstr, "dlx"}, {"reason", :longstr, "rejected"}, {"routing-keys", :array, [longstr: "dlx"]}, {"time", :timestamp, 1484651915}]]}], message_id: :undefined, persistent: true, priority: :undefined, redelivered: false, reply_to: :undefined, routing_key: "dlx",timestamp: :undefined, type: :undefined, user_id: :undefined}
+
+      assert Message.failed_count(meta) == 67
+    end
+
+    test "RabbitMQ 3.4 header" do
+      headers = [{"x-death", :array, [table: [{"reason", :longstr, "expired"}, {"queue", :longstr, "jobs.test_job.retry"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job.retry"]}], table: [{"reason", :longstr, "rejected"}, {"queue", :longstr, "jobs.test_job"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job"]}], table: [{"reason", :longstr, "expired"}, {"queue", :longstr, "jobs.test_job.retry"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job.retry"]}], table: [{"reason", :longstr, "rejected"}, {"queue", :longstr, "jobs.test_job"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job"]}], table: [{"reason", :longstr, "expired"}, {"queue", :longstr, "jobs.test_job.retry"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job.retry"]}], table: [{"reason", :longstr, "rejected"}, {"queue", :longstr, "jobs.test_job"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job"]}]]}]
+
+      meta = %{app_id: :undefined, cluster_id: :undefined, consumer_tag: "amq.ctag-6gbrfVhVEsg5UluIEagNcQ", content_encoding: :undefined, content_type: :undefined, correlation_id: :undefined, delivery_tag: 69, exchange: "", expiration: :undefined, headers: headers, message_id: :undefined, persistent: true, priority: :undefined, redelivered: false, reply_to: :undefined, routing_key: "dlx",timestamp: :undefined, type: :undefined, user_id: :undefined}
+
+      assert Message.failed_count(meta) == 3
+    end
+  end
+end


### PR DESCRIPTION
Support Travis CI. Since Travis CI uses RabbitMQ 3.4 (the latest stable is 3.6), support the message meta data format for the version too.