### PR TITLE
Implement Job.enqueue/2

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ end
 Then enqueue a job
 
 ```elixir
-:ok = TaskBunny.SyncPublisher.push(SampleJob, %{"id" => 123123})
+:ok = SampleJob.enqueue(%{"id" => 123123})
 ```
 
 The worker invokes the job with `SampleJob was invoked with ID=123123` in your logger output.

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -4,7 +4,7 @@ defmodule TaskBunny.Job do
 
   @callback perform(any) :: :ok | {:error, term}
 
-  alias TaskBunny.{Queue, Job}
+  alias TaskBunny.{Queue, Job, SyncPublisher}
 
   defmacro __using__(job_options \\ []) do
     quote do
@@ -43,6 +43,11 @@ defmodule TaskBunny.Job do
         namespace = Keyword.get(options, :namespace, unquote(@default_job_namespace))
 
         "#{namespace}.#{name}"
+      end
+
+      @spec enqueue(any) :: :ok | :failed
+      def enqueue(host \\ :default, payload) do
+        SyncPublisher.push(host, __MODULE__, payload)
       end
 
       @spec all_queues :: list(String.t)


### PR DESCRIPTION
As we discuss on https://github.com/shinyscorpion/task_bunny/issues/3, we want to have better enqueue interface. For now, I leave SyncPublisher but I will rename the module in the near future too.