### PR TITLE
Add error log to message body

### DIFF
--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -66,9 +66,7 @@ defmodule TaskBunny.Job do
 
       @spec declare_queue(atom) :: :ok
       def declare_queue(host \\ :default) do
-        Queue.declare_with_retry(
-          host, queue_name(), retry_interval: retry_interval()
-        )
+        Queue.declare_with_retry(host, queue_name())
         :ok
       catch
         :exit, e ->

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -13,7 +13,7 @@ defmodule TaskBunny.Message do
       "payload" => payload,
       "created_at" => DateTime.utc_now()
     }
-    |> Poison.encode!
+    |> Poison.encode!(pretty: true)
   end
 
   @doc """
@@ -59,80 +59,25 @@ defmodule TaskBunny.Message do
   end
 
   @doc """
-  Retrieves number of count the message was consumed and failed to process
-
-  ## Example
-
-      iex> meta = %{app_id: :undefined, cluster_id: :undefined, consumer_tag: "amq.ctag-6gbrfVhVEsg5UluIEagNcQ", content_encoding: :undefined, content_type: :undefined, correlation_id: :undefined, delivery_tag: 69, exchange: "", expiration: :undefined, headers: [{"x-death", :array, [table: [{"count", :long, 67}, {"exchange", :longstr, ""}, {"queue", :longstr, "dlx.retry"}, {"reason", :longstr, "expired"}, {"routing-keys", :array, [longstr: "dlx.retry"]}, {"time", :timestamp, 1484651945}], table: [{"count", :long, 67}, {"exchange", :longstr, ""},{"queue", :longstr, "dlx"}, {"reason", :longstr, "rejected"}, {"routing-keys", :array, [longstr: "dlx"]}, {"time", :timestamp, 1484651915}]]}], message_id: :undefined, persistent: true, priority: :undefined, redelivered: false, reply_to: :undefined, routing_key: "dlx",timestamp: :undefined, type: :undefined, user_id: :undefined}
-      iex> TaskBunny.Message.failed_count(meta)
-      67
+  Add an error log to message body.
   """
-  @spec failed_count(map | tuple | any) :: integer
-  def failed_count(meta)
-
-  def failed_count(%{headers: :undefined}), do: 0
-
-  def failed_count(%{headers: headers}) do
-    x_death = Enum.find headers, fn ({key, _, _}) ->
-      key == "x-death"
-    end
-
-    failed_count(x_death)
+  @spec add_error_log(String.t|map, any) :: String.t | map
+  def add_error_log(message, error) when is_map(message) do
+    error = %{
+      "result" => inspect(error),
+      "failed_at" => DateTime.utc_now(),
+      "pid" => inspect(self())
+    }
+    errors = (message["errors"] || []) |> List.insert_at(-1, error)
+    Map.merge(message, %{"errors" => errors})
   end
 
-  def failed_count({"x-death", :array, tables}) do
-    count =
-      tables
-      |> Enum.map(fn({_, attributes}) ->
-           count_attr = Enum.find attributes, fn ({key, _, _}) ->
-             key == "count"
-           end
-
-           case count_attr do
-             {_, _, count} -> count
-             _ -> 0
-           end
-         end)
-      |> Enum.max(fn -> 0 end)
-
-    if count > 0, do: count, else: failed_count_pre_3_6(tables)
+  def add_error_log(raw_message, error) do
+    raw_message
+    |> Poison.decode!()
+    |> add_error_log(error)
+    |> Poison.encode!(pretty: true)
   end
 
   def failed_count(_), do: 0
-
-  # Priort to 3.6, it doesn't contain count information.
-  # We need to count it up by ourselves.
-  @spec failed_count_pre_3_6(list) :: integer
-  defp failed_count_pre_3_6(tables) do
-    # List up queues
-    queues =
-      tables
-      |> Enum.map(fn ({_, tuples}) ->
-        tuple = Enum.find(tuples, fn ({key, _type, _value}) ->
-          key == "queue"
-        end)
-        case tuple do
-          {_, _, queue_name} -> queue_name
-          _ -> nil
-        end
-      end)
-      |> Enum.filter(fn (queue) -> queue end)
-
-    # Count up queues
-    # ["jobs.a.retry", "jobs.a", "jobs.a.retry", "jobs.a"]
-    # => %{"jobs.a.retry" => 2, "jobs.a" => 2}
-    # => then takes the max value
-
-    queues
-    |> Enum.reduce(%{}, fn (queue, counts) ->
-      if counts[queue] do
-        %{counts | queue => counts[queue] + 1}
-      else
-        Map.merge(counts, %{queue => 1})
-      end
-    end)
-    |> Map.to_list
-    |> Enum.map(fn ({_q, count}) -> count end)
-    |> Enum.max
-  end
 end

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -79,5 +79,20 @@ defmodule TaskBunny.Message do
     |> Poison.encode!(pretty: true)
   end
 
-  def failed_count(_), do: 0
+  @doc """
+  Returns a number of errors occurred for the message
+  """
+  @spec failed_count(String.t|map) :: integer
+  def failed_count(message) when is_map(message) do
+    case message["errors"] do
+      nil -> 0
+      errors -> length(errors)
+    end
+  end
+
+  def failed_count(raw_message) do
+    raw_message
+    |> Poison.decode!()
+    |> failed_count()
+  end
 end

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -66,6 +66,7 @@ defmodule TaskBunny.Message do
     error = %{
       "result" => inspect(error),
       "failed_at" => DateTime.utc_now(),
+      "host" => host(),
       "pid" => inspect(self())
     }
     errors = (message["errors"] || []) |> List.insert_at(-1, error)
@@ -77,6 +78,11 @@ defmodule TaskBunny.Message do
     |> Poison.decode!()
     |> add_error_log(error)
     |> Poison.encode!(pretty: true)
+  end
+
+  defp host() do
+    {:ok, host} = :inet.gethostname()
+    List.to_string(host)
   end
 
   @doc """

--- a/lib/task_bunny/publisher.ex
+++ b/lib/task_bunny/publisher.ex
@@ -27,7 +27,7 @@ defmodule TaskBunny.Publisher do
   defp do_publish(nil, _, _, _, _), do: {:error, "Failed to connect to AMQP host"}
 
   defp do_publish(conn, exchange, routing_key, message, options) do
-    Logger.debug "TaskBunny.Publisher: publish:\r\n #{exchange} - #{routing_key}: #{inspect message}"
+    Logger.debug "TaskBunny.Publisher: publish:\r\n #{exchange} - #{routing_key}: #{inspect message}. options = #{inspect options}"
 
     {:ok, channel} = AMQP.Channel.open(conn)
     :ok = AMQP.Basic.publish(channel, exchange, routing_key, message, options)

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -1,5 +1,6 @@
 defmodule TaskBunny.Queue do
   @moduledoc false
+  @default_retry_interval 120_000
 
   @spec declare_with_retry(%AMQP.Connection{} | atom, String.t, list) :: {map, map, map}
   def declare_with_retry(host, queue_name, options) when is_atom(host) do
@@ -13,17 +14,8 @@ defmodule TaskBunny.Queue do
     retry_queue = retry_queue_name(queue_name)
     rejected_queue = rejected_queue_name(queue_name)
 
-    retry_interval = options[:retry_interval] || 60_000
-
-    # Send dead lettered message to retry queue
-    main_options = [
-      arguments: [
-        {"x-dead-letter-exchange", :longstr, ""},
-        {"x-dead-letter-routing-key", :longstr, retry_queue}
-      ],
-      durable: true
-    ]
-    work = declare(channel, queue_name, main_options)
+    work = declare(channel, queue_name, [durable: true])
+    rejected = declare(channel, rejected_queue, [durable: true])
 
     # Set main queue as dead letter exchange of retry queue.
     # It will requeue the message once message TTL is over.
@@ -31,13 +23,11 @@ defmodule TaskBunny.Queue do
       arguments: [
         {"x-dead-letter-exchange", :longstr, ""},
         {"x-dead-letter-routing-key", :longstr, queue_name},
-        {"x-message-ttl", :long, retry_interval}
+        {"x-message-ttl", :long, @default_retry_interval}
       ],
       durable: true
     ]
     retry = declare(channel, retry_queue, retry_options)
-
-    rejected = declare(channel, rejected_queue, [durable: true])
 
     AMQP.Channel.close(channel)
 

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -3,7 +3,7 @@ defmodule TaskBunny.Queue do
 
   @spec declare_with_retry(%AMQP.Connection{} | atom, String.t) :: {map, map, map}
   def declare_with_retry(host, queue_name) when is_atom(host) do
-    conn = TaskBunny.Connection.get_connection(host)
+    conn = TaskBunny.Connection.get_connection!(host)
     declare_with_retry(conn, queue_name)
   end
 

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -1,14 +1,13 @@
 defmodule TaskBunny.Queue do
   @moduledoc false
-  @default_retry_interval 120_000
 
-  @spec declare_with_retry(%AMQP.Connection{} | atom, String.t, list) :: {map, map, map}
-  def declare_with_retry(host, queue_name, options) when is_atom(host) do
+  @spec declare_with_retry(%AMQP.Connection{} | atom, String.t) :: {map, map, map}
+  def declare_with_retry(host, queue_name) when is_atom(host) do
     conn = TaskBunny.Connection.get_connection(host)
-    declare_with_retry(conn, queue_name, options)
+    declare_with_retry(conn, queue_name)
   end
 
-  def declare_with_retry(connection, queue_name, options) do
+  def declare_with_retry(connection, queue_name) do
     {:ok, channel} = AMQP.Channel.open(connection)
 
     retry_queue = retry_queue_name(queue_name)
@@ -22,8 +21,7 @@ defmodule TaskBunny.Queue do
     retry_options = [
       arguments: [
         {"x-dead-letter-exchange", :longstr, ""},
-        {"x-dead-letter-routing-key", :longstr, queue_name},
-        {"x-message-ttl", :long, @default_retry_interval}
+        {"x-dead-letter-routing-key", :longstr, queue_name}
       ],
       durable: true
     ]

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -57,4 +57,21 @@ defmodule TaskBunny.TestSupport.JobTestHelper do
   def teardown do
     :meck.unload
   end
+
+  def wait_for_connection(host) do
+    Enum.find_value 1..100, fn (_) ->
+      case TaskBunny.Connection.monitor_connection(host, self()) do
+        :ok -> true
+        _ ->
+          :timer.sleep(10)
+          false
+      end
+    end || raise "connection process is not up"
+
+    receive do
+      {:connected, conn} -> conn
+    after
+      1_000 -> raise "failed to connect to #{host}"
+    end
+  end
 end

--- a/test/task_bunny/message_test.exs
+++ b/test/task_bunny/message_test.exs
@@ -36,19 +36,15 @@ defmodule TaskBunny.MessageTest do
     end
   end
 
-  describe "failed_count" do
-    test "RabbitMQ 3.6 header" do
-      meta = %{app_id: :undefined, cluster_id: :undefined, consumer_tag: "amq.ctag-6gbrfVhVEsg5UluIEagNcQ", content_encoding: :undefined, content_type: :undefined, correlation_id: :undefined, delivery_tag: 69, exchange: "", expiration: :undefined, headers: [{"x-death", :array, [table: [{"count", :long, 67}, {"exchange", :longstr, ""}, {"queue", :longstr, "dlx.retry"}, {"reason", :longstr, "expired"}, {"routing-keys", :array, [longstr: "dlx.retry"]}, {"time", :timestamp, 1484651945}], table: [{"count", :long, 67}, {"exchange", :longstr, ""},{"queue", :longstr, "dlx"}, {"reason", :longstr, "rejected"}, {"routing-keys", :array, [longstr: "dlx"]}, {"time", :timestamp, 1484651915}]]}], message_id: :undefined, persistent: true, priority: :undefined, redelivered: false, reply_to: :undefined, routing_key: "dlx",timestamp: :undefined, type: :undefined, user_id: :undefined}
+  describe "add_error_log" do
+    @tag timeout: 1000
+    test "adds error information to the message" do
+      message = Message.encode(NameJob, %{"name" => "Joe"})
+      error = {:error, "HTTP Request error"}
+      new_message = Message.add_error_log(message, error)
+      {:ok, %{"errors" => [added | _]}} = Message.decode(new_message)
 
-      assert Message.failed_count(meta) == 67
-    end
-
-    test "RabbitMQ 3.4 header" do
-      headers = [{"x-death", :array, [table: [{"reason", :longstr, "expired"}, {"queue", :longstr, "jobs.test_job.retry"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job.retry"]}], table: [{"reason", :longstr, "rejected"}, {"queue", :longstr, "jobs.test_job"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job"]}], table: [{"reason", :longstr, "expired"}, {"queue", :longstr, "jobs.test_job.retry"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job.retry"]}], table: [{"reason", :longstr, "rejected"}, {"queue", :longstr, "jobs.test_job"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job"]}], table: [{"reason", :longstr, "expired"}, {"queue", :longstr, "jobs.test_job.retry"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job.retry"]}], table: [{"reason", :longstr, "rejected"}, {"queue", :longstr, "jobs.test_job"}, {"time", :timestamp, 1487256438}, {"exchange", :longstr, ""}, {"routing-keys", :array, [longstr: "jobs.test_job"]}]]}]
-
-      meta = %{app_id: :undefined, cluster_id: :undefined, consumer_tag: "amq.ctag-6gbrfVhVEsg5UluIEagNcQ", content_encoding: :undefined, content_type: :undefined, correlation_id: :undefined, delivery_tag: 69, exchange: "", expiration: :undefined, headers: headers, message_id: :undefined, persistent: true, priority: :undefined, redelivered: false, reply_to: :undefined, routing_key: "dlx",timestamp: :undefined, type: :undefined, user_id: :undefined}
-
-      assert Message.failed_count(meta) == 3
+      assert added["result"] == inspect(error)
     end
   end
 end

--- a/test/task_bunny/supervisor_test.exs
+++ b/test/task_bunny/supervisor_test.exs
@@ -24,6 +24,7 @@ defmodule TaskBunny.SupervisorTest do
     JobTestHelper.setup
 
     {:ok, pid} = TaskBunny.Supervisor.start_link(:supevisor_test)
+    :timer.sleep(50)
 
     on_exit fn ->
       :meck.unload

--- a/test/task_bunny/supervisor_test.exs
+++ b/test/task_bunny/supervisor_test.exs
@@ -51,7 +51,7 @@ defmodule TaskBunny.SupervisorTest do
       # Close the connection
       conn = Connection.get_connection(@host)
       AMQP.Connection.close(conn)
-      :timer.sleep(10)
+      :timer.sleep(50)
 
       new_conn_pid = Process.whereis(conn_name)
       new_work_pid = Process.whereis(work_name)


### PR DESCRIPTION
We would like to add failed logs to the message so it helps identifying issue instantly.

Here is the example message.

```javascript
{
  "payload": {
    "name": "Joe"
  },
  "job": "TaskBunny.MessageTest.NameJob",
  "errors": [
    {
      "result": "{:error, \"HTTP Request error\"}",
      "pid": "#PID<0.244.0>",
      "failed_at": "2017-02-23T10:08:51.366951Z"
    }
  ],
  "created_at": "2017-02-23T10:08:51.356652Z"
}
```

The errors are sorted in chronological order (order to newer).

To add error message, we stopped using dead letter exchange on worker queue. You need to reset existing queues after this change because of that.

We still use dead letter exchange on retry queue. However it no longer has expiration time on queue layer and it's set to each messages. It will allow us to write more complicated retry logic like [this](https://github.com/lantins/resque-retry#-exponential-backoff) in future.