### PR TITLE
Provide a way to gracefully halt workers

### DIFF
--- a/lib/task_bunny/consumer.ex
+++ b/lib/task_bunny/consumer.ex
@@ -23,6 +23,14 @@ defmodule TaskBunny.Consumer do
   end
 
   @doc """
+  Cancel consumer to stop receiving messages.
+  """
+  @spec cancel(AMQP.Channel.t, String.t) :: {:ok, String.t}
+  def cancel(channel, consumer_tag) do
+    AMQP.Basic.cancel(channel, consumer_tag)
+  end
+
+  @doc """
   Acknowledges to the message.
   """
   @spec ack(%AMQP.Channel{}, map, boolean) :: :ok

--- a/lib/task_bunny/status/worker.ex
+++ b/lib/task_bunny/status/worker.ex
@@ -14,6 +14,7 @@ defmodule TaskBunny.Status.Worker do
     job: atom,
     runners: integer,
     channel: false | String.t,
+    consuming: boolean,
     stats: %{
       failed: integer,
       succeeded: integer,
@@ -26,6 +27,7 @@ defmodule TaskBunny.Status.Worker do
     :job,
     runners: 0,
     channel: false,
+    consuming: false,
     stats: %{
       failed: 0,
       succeeded: 0,

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -13,14 +13,14 @@ defmodule TaskBunny.Supervisor do
   alias TaskBunny.{Connection, Config, WorkerSupervisor}
 
   @spec start_link(atom) :: {:ok, pid} | {:error, term}
-  def start_link(name \\ __MODULE__) do
-    Supervisor.start_link(__MODULE__, [], name: name)
+  def start_link(name \\ __MODULE__, wsv_name \\ WorkerSupervisor) do
+    Supervisor.start_link(__MODULE__, [wsv_name], name: name)
   end
 
   @spec init(list()) ::
     {:ok, {:supervisor.sup_flags, [Supervisor.Spec.spec]}} |
     :ignore
-  def init([]) do
+  def init([wsv_name]) do
     # Add Connection severs for each hosts
     connections = Enum.map Config.hosts(), fn (host) ->
       worker(Connection, [host])
@@ -30,7 +30,7 @@ defmodule TaskBunny.Supervisor do
     children =
       case Config.auto_start?() do
         true ->
-          connections ++ [supervisor(WorkerSupervisor, [get_jobs()])]
+          connections ++ [supervisor(WorkerSupervisor, [get_jobs(), wsv_name])]
         false ->
           []
       end

--- a/test/task_bunny/status/worker_test.exs
+++ b/test/task_bunny/status/worker_test.exs
@@ -8,6 +8,7 @@ defmodule TaskBunny.Status.WorkerTest do
 
   @host :worker_test
   @supervisor :worker_test_supervisor
+  @worker_supervisor :worker_test_worker_supervisor
 
   defmodule RejectJob do
     use TaskBunny.Job
@@ -52,7 +53,7 @@ defmodule TaskBunny.Status.WorkerTest do
     setup_config()
     JobTestHelper.setup()
 
-    TaskBunny.Supervisor.start_link(:worker_test_supervisor)
+    TaskBunny.Supervisor.start_link(@supervisor, @worker_supervisor)
     JobTestHelper.wait_for_connection(@host)
 
     on_exit fn ->

--- a/test/task_bunny/status_test.exs
+++ b/test/task_bunny/status_test.exs
@@ -22,7 +22,7 @@ defmodule TaskBunny.StatusTest do
 
     JobTestHelper.setup
 
-    {:ok, pid} = TaskBunny.Supervisor.start_link(:foo_supervisor)
+    {:ok, pid} = TaskBunny.Supervisor.start_link(:foo_supervisor, :bar_supervisor)
 
     on_exit fn ->
       :meck.unload

--- a/test/task_bunny/supervisor_test.exs
+++ b/test/task_bunny/supervisor_test.exs
@@ -48,7 +48,7 @@ defmodule TaskBunny.SupervisorTest do
     setup_config()
     JobTestHelper.setup()
 
-    TaskBunny.Supervisor.start_link(:supevisor_test)
+    TaskBunny.Supervisor.start_link(:supevisor_test, :wsv_supervisor_test)
     JobTestHelper.wait_for_connection(@host)
 
     on_exit fn ->

--- a/test/task_bunny/worker_supervisor_test.exs
+++ b/test/task_bunny/worker_supervisor_test.exs
@@ -1,10 +1,11 @@
 defmodule TaskBunny.WorkerSupervisorTest do
-  use ExUnit.Case
-
+  use ExUnit.Case, async: false
   import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.WorkerSupervisor
+  alias TaskBunny.{Connection, Queue, WorkerSupervisor}
   alias TaskBunny.TestSupport.JobTestHelper
   alias TaskBunny.TestSupport.JobTestHelper.TestJob
+
+  @test_job_worker :"TaskBunny.Worker.Elixir.TaskBunny.TestSupport.JobTestHelper.TestJob"
 
   setup do
     clean(TestJob.all_queues())
@@ -17,19 +18,80 @@ defmodule TaskBunny.WorkerSupervisorTest do
     :ok
   end
 
-  test "starts job worker" do
+  defp start_worker_supervisor do
     jobs = [{:default, TestJob, 3}]
+    {:ok, pid} = WorkerSupervisor.start_link(jobs, :woker_supervisor_test)
+    pid
+  end
 
-    {:ok, pid} = WorkerSupervisor.start_link(jobs)
+  defp wait_for_worker_up(name \\ @test_job_worker) do
+    Enum.find_value 1..100, fn (_) ->
+      if pid = Process.whereis(name) do
+        %{consuming: consuming} = GenServer.call(pid, :status)
+        !is_nil(consuming)
+        :timer.sleep(10)
+        true
+      else
+        :timer.sleep(10)
+        false
+      end
+    end
+  end
+
+  test "starts job worker" do
+    pid = start_worker_supervisor()
     %{active: active} = Supervisor.count_children(pid)
     assert active == 1
 
     payload = %{"hello" => "world"}
     TestJob.enqueue(payload)
 
-    JobTestHelper.wait_for_perform
+    JobTestHelper.wait_for_perform()
     assert List.first(JobTestHelper.performed_payloads) == payload
 
     Supervisor.stop(pid)
+  end
+
+  describe "graceful_halt" do
+    test "stops workers to consuming the job" do
+      pid = start_worker_supervisor()
+      wait_for_worker_up()
+
+      assert WorkerSupervisor.graceful_halt(pid, 1000) == :ok
+
+      payload = %{"hello" => "world2"}
+      TestJob.enqueue(payload)
+      :timer.sleep(50)
+
+      assert JobTestHelper.performed_count() == 0
+
+      %{message_count: count} = Queue.state(
+        Connection.get_connection(), TestJob.queue_name()
+      )
+
+      assert count == 1
+    end
+
+    test "doesn't stop workers if the current running job didn't finish before timeout" do
+      pid = start_worker_supervisor()
+      wait_for_worker_up()
+
+      payload = %{"sleep" => 60_000}
+      TestJob.enqueue(payload)
+      JobTestHelper.wait_for_perform()
+
+      assert {:error, _} = WorkerSupervisor.graceful_halt(pid, 100)
+    end
+
+    test "waits for current runnning jobs to be finished" do
+      pid = start_worker_supervisor()
+      wait_for_worker_up()
+
+      payload = %{"sleep" => 200}
+      TestJob.enqueue(payload)
+      JobTestHelper.wait_for_perform()
+
+      assert :ok = WorkerSupervisor.graceful_halt(pid, 1000)
+    end
   end
 end


### PR DESCRIPTION
Introduce `Worker.stop_consumer/1`, `WorkerSupervisor.graceful_halt/1` and `WorkerSupervisor.graceful_halt/2` to provide a way shut down TaskBunny safely. `WorkerSupervisor.graceful_halt/1` will wait for running jobs to finish.