### PR TITLE
Decouple queue and job

### DIFF
--- a/lib/mix/tasks/task_bunny.queue.reset.ex
+++ b/lib/mix/tasks/task_bunny.queue.reset.ex
@@ -10,7 +10,7 @@ defmodule Mix.Tasks.TaskBunny.Queue.Reset do
   So all existing messages in the queues will go away.
   """
 
-  alias TaskBunny.{Connection, Config}
+  alias TaskBunny.{Connection, Config, Queue}
 
   @doc false
   @spec run(list) :: any
@@ -22,15 +22,15 @@ defmodule Mix.Tasks.TaskBunny.Queue.Reset do
       Connection.start_link(host)
     end
 
-    Config.jobs
-    |> Enum.each(fn (job) -> reset_queue(job) end)
+    Config.queues
+    |> Enum.each(fn (queue) -> reset_queue(queue) end)
   end
 
-  defp reset_queue(job_info) do
-    Mix.shell.info "Resetting queues for #{inspect job_info}"
+  defp reset_queue(queue) do
+    Mix.shell.info "Resetting queues for #{inspect queue}"
+    host = queue[:host] || :default
 
-    job = job_info[:job]
-    job.delete_queue()
-    job.declare_queue()
+    Queue.delete_with_subqueues(host, queue[:name])
+    Queue.declare_with_subqueues(host, queue[:name])
   end
 end

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -33,7 +33,7 @@ defmodule TaskBunny.Config do
          is_atom(key) && Atom.to_string(key) =~ ~r/queue$/
        end)
     |> Enum.map(fn ({_, queue_config}) -> parse_queue_config(queue_config) end)
-    |> Enum.flat_map(fn (queues) -> queues end)
+    |> Enum.flat_map(fn (queue_list) -> queue_list end)
   end
 
   # Get queue config and returns list of queues with namespace
@@ -78,12 +78,11 @@ defmodule TaskBunny.Config do
       match_job?(job, queue[:jobs])
     end) || default_queue()
 
-
     if queue, do: queue[:name], else: nil
   end
 
   @spec default_queue :: keyword | nil
-  defp default_queue() do
+  defp default_queue do
     Enum.find(queues(), fn (queue) ->
       queue[:jobs] == :default
     end)
@@ -122,19 +121,6 @@ defmodule TaskBunny.Config do
 
   defp match_job?(job, jobs) when is_list(jobs) do
     Enum.any?(jobs, fn (pattern) -> match_job?(job, pattern) end)
-  end
-
-  @doc """
-  Returns jobs in config.
-  """
-  @spec jobs :: [keyword]
-  def jobs do
-    :task_bunny
-    |> Application.get_all_env
-    |> Enum.filter(fn ({key, _}) ->
-         is_atom(key) && Atom.to_string(key) =~ ~r/jobs$/
-       end)
-    |> Enum.flat_map(fn ({_, job_list}) -> job_list end)
   end
 
   @doc """

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -3,6 +3,8 @@ defmodule TaskBunny.Config do
   Modules that help you access to TaskBunny config values
   """
 
+  @default_concurrency 2
+
   @doc """
   Returns list of hosts in config.
   """
@@ -18,6 +20,108 @@ defmodule TaskBunny.Config do
   @spec connect_options(host :: atom) :: list | String.t
   def connect_options(host) do
     hosts_config()[host][:connect_options] || raise "Can not find host '#{host}' in config"
+  end
+
+  @doc """
+  Returns queues in config.
+  """
+  @spec queues :: [keyword]
+  def queues do
+    :task_bunny
+    |> Application.get_all_env
+    |> Enum.filter(fn ({key, _}) ->
+         is_atom(key) && Atom.to_string(key) =~ ~r/queue$/
+       end)
+    |> Enum.map(fn ({_, queue_config}) -> parse_queue_config(queue_config) end)
+    |> Enum.flat_map(fn (queues) -> queues end)
+  end
+
+  # Get queue config and returns list of queues with namespace
+  defp parse_queue_config(queue_config) do
+    namespace = queue_config[:namespace] || ""
+
+    queue_config[:queues]
+    |> Enum.map(fn (queue) ->
+      Keyword.merge(queue, [name: namespace <> queue[:name]])
+    end)
+  end
+
+  @doc """
+  Returns workers in config.
+  """
+  @spec workers :: [keyword]
+  def workers do
+    queues()
+    |> Enum.filter(fn (queue) -> queue[:worker] != false end)
+    |> Enum.map(fn (queue) ->
+      concurrency =
+        if queue[:worker] && queue[:worker][:concurrency] do
+          queue[:worker][:concurrency]
+        else
+          @default_concurrency
+        end
+
+      [
+        queue: queue[:name],
+        concurrency: concurrency,
+        host: queue[:host] || :default
+      ]
+    end)
+  end
+
+  @doc """
+  Returns queue for the given job
+  """
+  @spec queue_for_job(atom) :: String.t
+  def queue_for_job(job) do
+    queue = Enum.find(queues(), fn (queue) ->
+      match_job?(job, queue[:jobs])
+    end) || default_queue()
+
+
+    if queue, do: queue[:name], else: nil
+  end
+
+  @spec default_queue :: keyword | nil
+  defp default_queue() do
+    Enum.find(queues(), fn (queue) ->
+      queue[:jobs] == :default
+    end)
+  end
+
+  @spec match_job?(atom, atom|String.t|list) :: boolean
+  defp match_job?(job, condition)
+
+  # e.g.
+  # match_job?(TestJob, TestJob)
+  # => true
+  # match_job?(TestJob, SampleJob)
+  # => false
+  defp match_job?(job, condition) when is_atom(condition), do: job == condition
+
+  # e.g.
+  # match_job?(TestJob, "TestJob")
+  # => true
+  # match_job?(TB.TestJob, "TB.*")
+  # => true
+  # match_job?(Elixir.TB.TestJob, "TB.*")
+  # => true
+  # match_job?(TestJob, "SampleJob")
+  # => false
+  defp match_job?(job, pattern) when is_binary(pattern) do
+    job_name = job |> Atom.to_string() |> String.trim_leading("Elixir.")
+
+    pattern = pattern
+            |> Regex.escape()
+            |> String.replace("\\*", ".*")
+
+    regex = "^#{pattern}$" |> Regex.compile!
+
+    String.match?(job_name, regex)
+  end
+
+  defp match_job?(job, jobs) when is_list(jobs) do
+    Enum.any?(jobs, fn (pattern) -> match_job?(job, pattern) end)
   end
 
   @doc """

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -1,72 +1,39 @@
 defmodule TaskBunny.Job do
   @moduledoc false
-  @default_job_namespace "jobs"
 
   @callback perform(any) :: :ok | {:error, term}
 
-  alias TaskBunny.{Queue, Job, Message, Publisher}
+  alias TaskBunny.{Config, Queue, Job, Message, Publisher}
 
-  defmacro __using__(job_options \\ []) do
+  defmacro __using__(_options \\ []) do
     quote do
       @behaviour Job
       require Logger
 
-      defp snake_case(name) do
-        name
-        |> String.replace(~r/([^.])([A-Z])/, "\\1_\\2")
-        |> String.downcase
-      end
-
-      defp module_queue_name(true) do
-        __MODULE__
-        |> Atom.to_string
-        |> String.replace_prefix("Elixir.", "")
-        |> snake_case
-      end
-
-      defp module_queue_name(_) do
-        __MODULE__
-        |> Atom.to_string
-        |> String.replace(~r/^.*?([^.]+)$/, "\\1") # Only end string that doesn't have a ".".
-        |> snake_case
-      end
-
-      @spec queue_name :: String.t
-      def queue_name do
-        options = unquote(job_options)
-
-        name = case Keyword.get(options, :id, nil) do
-          nil -> options |> Keyword.get(:full, false) |> module_queue_name
-          id -> id
-        end
-
-        namespace = Keyword.get(options, :namespace, unquote(@default_job_namespace))
-
-        "#{namespace}.#{name}"
-      end
-
       @spec enqueue(any, keyword) :: :ok | {:error, any}
       def enqueue(payload, options \\ []) do
-        host = options[:host] || :default
-        queue = options[:queue] || queue_name()
+        queue_data = Config.queue_for_job(__MODULE__)
+
+        queue = options[:queue] || queue_data[:name]
+        host = options[:host] || queue_data[:host] || :default
         message = Message.encode(__MODULE__, payload)
 
+        do_enqueue(host, queue, message)
+      end
+
+      @spec do_enqueue(atom, String.t|nil, String.t) :: :ok | {:error, any}
+      defp do_enqueue(host, nil, message) do
+        {:error, "Can't find a queue for #{__MODULE__}"}
+      end
+
+      defp do_enqueue(host, queue, message) do
         declare_queue(host, queue)
         Publisher.publish(host, queue, message)
       end
 
-      @spec all_queues :: list(String.t)
-      def all_queues do
-        [
-          queue_name(),
-          Queue.retry_queue_name(queue_name()),
-          Queue.rejected_queue_name(queue_name())
-        ]
-      end
-
       @spec declare_queue(atom, String.t) :: :ok
-      def declare_queue(host, queue) do
-        Queue.declare_with_retry(host, queue)
+      defp declare_queue(host, queue) do
+        Queue.declare_with_subqueues(host, queue)
         :ok
       catch
         :exit, e ->
@@ -77,12 +44,6 @@ defmodule TaskBunny.Job do
           Logger.error "failed to declare queue for #{queue}. If you have changed the queue configuration, you have to delete the queue and create it again. Error: #{inspect e}"
 
           {:error, {:exit, e}}
-      end
-
-      # FIXME: Maybe we need to remove this?
-      @spec delete_queue(atom) :: :ok
-      def delete_queue(host \\ :default) do
-        Queue.delete_with_retry(host, queue_name())
       end
 
       @doc false

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -19,7 +19,7 @@ defmodule TaskBunny.Message do
   @doc """
   Decode message body in JSON to map
   """
-  @spec decode(String.t) :: map
+  @spec decode(String.t) :: {:ok, map} | {:error, any}
   def decode(message) do
     case Poison.decode(message) do
       {:ok, decoded} ->
@@ -80,9 +80,9 @@ defmodule TaskBunny.Message do
     |> Poison.encode!(pretty: true)
   end
 
-  defp host() do
-    {:ok, host} = :inet.gethostname()
-    List.to_string(host)
+  defp host do
+    {:ok, hostname} = :inet.gethostname()
+    List.to_string(hostname)
   end
 
   @doc """

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -66,6 +66,17 @@ defmodule TaskBunny.Queue do
     state
   end
 
+  @doc """
+  Returns all sub queues for the work queue.
+  """
+  @spec sub_queues(String.t) :: [String.t]
+  def sub_queues(queue) do
+    [
+      retry_queue_name(queue),
+      rejected_queue_name(queue)
+    ]
+  end
+
   @spec retry_queue_name(String.t) :: String.t
   def retry_queue_name(queue_name) do
     queue_name <> ".retry"

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -1,19 +1,26 @@
 defmodule TaskBunny.Queue do
-  @moduledoc false
+  @doc """
+  Conviniences for accessing TaskBunny queues.
 
-  @spec declare_with_retry(%AMQP.Connection{} | atom, String.t) :: {map, map, map}
-  def declare_with_retry(host, queue_name) when is_atom(host) do
+  When you have a worker queue called "task_bunny", TaskBunny defines the following sub queues with it.
+
+  - task_bunny.retry: queues for retry
+  - task_bunny.rejected: queues for rejected message (failed more than max retries or wrong message format)
+  """
+
+  @spec declare_with_subqueues(%AMQP.Connection{} | atom, String.t) :: {map, map, map}
+  def declare_with_subqueues(host, work_queue) when is_atom(host) do
     conn = TaskBunny.Connection.get_connection!(host)
-    declare_with_retry(conn, queue_name)
+    declare_with_subqueues(conn, work_queue)
   end
 
-  def declare_with_retry(connection, queue_name) do
+  def declare_with_subqueues(connection, work_queue) do
     {:ok, channel} = AMQP.Channel.open(connection)
 
-    retry_queue = retry_queue_name(queue_name)
-    rejected_queue = rejected_queue_name(queue_name)
+    retry_queue = retry_queue(work_queue)
+    rejected_queue = rejected_queue(work_queue)
 
-    work = declare(channel, queue_name, [durable: true])
+    work = declare(channel, work_queue, [durable: true])
     rejected = declare(channel, rejected_queue, [durable: true])
 
     # Set main queue as dead letter exchange of retry queue.
@@ -21,7 +28,7 @@ defmodule TaskBunny.Queue do
     retry_options = [
       arguments: [
         {"x-dead-letter-exchange", :longstr, ""},
-        {"x-dead-letter-routing-key", :longstr, queue_name}
+        {"x-dead-letter-routing-key", :longstr, work_queue}
       ],
       durable: true
     ]
@@ -32,27 +39,29 @@ defmodule TaskBunny.Queue do
     {work, retry, rejected}
   end
 
-  @spec delete_with_retry(%AMQP.Connection{} | atom, String.t) :: :ok
-  def delete_with_retry(host, queue_name) when is_atom(host) do
+  @spec delete_with_subqueues(%AMQP.Connection{} | atom, String.t) :: :ok
+  def delete_with_subqueues(host, work_queue) when is_atom(host) do
     conn = TaskBunny.Connection.get_connection(host)
-    delete_with_retry(conn, queue_name)
+    delete_with_subqueues(conn, work_queue)
   end
 
-  def delete_with_retry(connection, queue_name) do
+  def delete_with_subqueues(connection, work_queue) do
     {:ok, channel} = AMQP.Channel.open(connection)
 
-    AMQP.Queue.delete(channel, queue_name)
-    AMQP.Queue.delete(channel, retry_queue_name(queue_name))
-    AMQP.Queue.delete(channel, rejected_queue_name(queue_name))
+    work_queue
+    |> queue_with_subqueues()
+    |> Enum.each(fn (queue) ->
+      AMQP.Queue.delete(channel, queue)
+    end)
 
     AMQP.Channel.close(channel)
     :ok
   end
 
   @spec declare(%AMQP.Channel{}, String.t, keyword) :: map
-  def declare(channel, queue_name, options \\ []) do
+  def declare(channel, queue, options \\ []) do
     options = options ++ [durable: true]
-    {:ok, state} = AMQP.Queue.declare(channel, queue_name, options)
+    {:ok, state} = AMQP.Queue.declare(channel, queue, options)
 
     state
   end
@@ -67,23 +76,31 @@ defmodule TaskBunny.Queue do
   end
 
   @doc """
+  Returns a list that contains the queue and its subqueue
+  """
+  @spec queue_with_subqueues(String.t) :: [String.t]
+  def queue_with_subqueues(work_queue) do
+    [work_queue] ++ subqueues(work_queue)
+  end
+
+  @doc """
   Returns all sub queues for the work queue.
   """
-  @spec sub_queues(String.t) :: [String.t]
-  def sub_queues(queue) do
+  @spec subqueues(String.t) :: [String.t]
+  def subqueues(work_queue) do
     [
-      retry_queue_name(queue),
-      rejected_queue_name(queue)
+      retry_queue(work_queue),
+      rejected_queue(work_queue)
     ]
   end
 
-  @spec retry_queue_name(String.t) :: String.t
-  def retry_queue_name(queue_name) do
-    queue_name <> ".retry"
+  @spec retry_queue(String.t) :: String.t
+  def retry_queue(work_queue) do
+    work_queue <> ".retry"
   end
 
-  @spec rejected_queue_name(String.t) :: String.t
-  def rejected_queue_name(queue_name) do
-    queue_name <> ".rejected"
+  @spec rejected_queue(String.t) :: String.t
+  def rejected_queue(work_queue) do
+    work_queue <> ".rejected"
   end
 end

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -1,5 +1,5 @@
 defmodule TaskBunny.Queue do
-  @doc """
+  @moduledoc """
   Conviniences for accessing TaskBunny queues.
 
   When you have a worker queue called "task_bunny", TaskBunny defines the following sub queues with it.

--- a/lib/task_bunny/status.ex
+++ b/lib/task_bunny/status.ex
@@ -123,7 +123,7 @@ defmodule TaskBunny.Status do
     supervisor
     |> get_workers_status()
     |> Enum.map(fn worker -> %{
-          job: worker.job,
+          queue: worker.queue,
           runners: worker.runners,
           channel: worker.channel,
           succeeded: worker.stats.succeeded,
@@ -136,10 +136,10 @@ defmodule TaskBunny.Status do
   @spec get_worker_metrics(Worker.t, {list, list, list, list}) :: {list, list, list, list}
   defp get_worker_metrics(worker, {runners, succeeded, failed, rejected}) do
     {
-      [{worker.runners, [job: worker.job]} | runners],
-      [{worker.stats.succeeded, [job: worker.job]} | succeeded],
-      [{worker.stats.failed, [job: worker.job]} | failed],
-      [{worker.stats.rejected, [job: worker.job]} | rejected]
+      [{worker.runners, [queue: worker.queue]} | runners],
+      [{worker.stats.succeeded, [queue: worker.queue]} | succeeded],
+      [{worker.stats.failed, [queue: worker.queue]} | failed],
+      [{worker.stats.rejected, [queue: worker.queue]} | rejected]
     }
   end
 end

--- a/lib/task_bunny/status/worker.ex
+++ b/lib/task_bunny/status/worker.ex
@@ -5,13 +5,13 @@ defmodule TaskBunny.Status.Worker do
 
   @typedoc ~S"""
   The Worker status contains the follow fields:
-    - `job`, the `Job` for the `Worker`.
+    - `queue`, the name of queue the worker is listening to.
     - `runners`, the amount of runners currently running the `Job`.
     - `channel`, the connected channel with consumer tag or false if not connected.
     - `stats`, the amount of failed and succeeded jobs.
   """
   @type t :: %__MODULE__{
-    job: atom,
+    queue: String.t,
     runners: integer,
     channel: false | String.t,
     consuming: boolean,
@@ -22,9 +22,9 @@ defmodule TaskBunny.Status.Worker do
     },
   }
 
-  @enforce_keys [:job]
+  @enforce_keys [:queue]
   defstruct [
-    :job,
+    queue: nil,
     runners: 0,
     channel: false,
     consuming: false,

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -12,7 +12,7 @@ defmodule TaskBunny.Supervisor do
   use Supervisor
   alias TaskBunny.{Connection, Config, WorkerSupervisor}
 
-  @spec start_link(atom) :: {:ok, pid} | {:error, term}
+  @spec start_link(atom, atom) :: {:ok, pid} | {:error, term}
   def start_link(name \\ __MODULE__, wsv_name \\ WorkerSupervisor) do
     Supervisor.start_link(__MODULE__, [wsv_name], name: name)
   end

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -30,18 +30,11 @@ defmodule TaskBunny.Supervisor do
     children =
       case Config.auto_start?() do
         true ->
-          connections ++ [supervisor(WorkerSupervisor, [get_jobs(), wsv_name])]
+          connections ++ [supervisor(WorkerSupervisor, [wsv_name])]
         false ->
           []
       end
 
     supervise(children, strategy: :one_for_all)
-  end
-
-  defp get_jobs do
-    Config.jobs()
-    |> Enum.map(fn (job) ->
-      {job[:host] || :default, job[:job], job[:concurrency]}
-    end)
   end
 end

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -9,7 +9,7 @@ defmodule TaskBunny.Worker do
                    Publisher, Worker, Message}
 
   @type t ::%__MODULE__{
-    job: atom,
+    queue: String.t,
     host: atom,
     concurrency: integer,
     channel: AMQP.Channel.t | nil,
@@ -23,7 +23,7 @@ defmodule TaskBunny.Worker do
   }
 
   defstruct [
-    :job,
+    queue: nil,
     host: :default,
     concurrency: 1,
     channel: nil,
@@ -39,17 +39,14 @@ defmodule TaskBunny.Worker do
   @doc """
   Starts a worker for a job with concurrency
   """
-  @spec start_link({atom, integer}) :: GenServer.on_start
-  def start_link({job, concurrency}) do
-    start_link(%Worker{job: job, concurrency: concurrency})
-  end
-
-  @doc """
-  Starts a worker for a job with concurrency on the host
-  """
-  @spec start_link({atom, atom, integer}) :: GenServer.on_start
-  def start_link({host, job, concurrency}) do
-    start_link(%Worker{host: host, job: job, concurrency: concurrency})
+  @spec start_link(list) :: GenServer.on_start
+  def start_link(config) when is_list(config) do
+    %Worker{
+      host: config[:host] || :default,
+      queue: config[:queue],
+      concurrency: config[:concurrency]
+    }
+    |> start_link()
   end
 
   @doc """
@@ -57,7 +54,7 @@ defmodule TaskBunny.Worker do
   """
   @spec start_link(t) :: GenServer.on_start
   def start_link(state = %Worker{}) do
-    GenServer.start_link(__MODULE__, state, name: pname(state.job))
+    GenServer.start_link(__MODULE__, state, name: pname(state.queue))
   end
 
   @doc """
@@ -65,7 +62,7 @@ defmodule TaskBunny.Worker do
   """
   @spec init(t) :: {:ok, t} | {:stop, :connection_not_ready}
   def init(state = %Worker{}) do
-    Logger.info "TaskBunny.Worker initializing with #{inspect state.job} and maximum #{inspect state.concurrency} concurrent jobs: PID: #{inspect self()}"
+    Logger.info log_msg("initializing", state)
 
     case Connection.monitor_connection(state.host, self()) do
       :ok ->
@@ -82,7 +79,7 @@ defmodule TaskBunny.Worker do
   """
   @spec terminate(any, TaskBunny.Worker.t) :: :normal
   def terminate(_reason, state) do
-    Logger.info "TaskBunny.Worker termintating: PID: #{inspect self()}"
+    Logger.info log_msg("terminating", state)
 
     if state.channel do
       AMQP.Channel.close(state.channel)
@@ -113,23 +110,23 @@ defmodule TaskBunny.Worker do
 
   def handle_info({:stop_consumer}, state = %Worker{}) do
     if state.channel && state.consumer_tag do
-      Logger.info "Stop consuming #{inspect state.job} - #{inspect self()}"
+      Logger.info log_msg("stop consuming", state)
       Consumer.cancel(state.channel, state.consumer_tag)
       {:noreply, %{state | consumer_tag: nil}}
     else
-      Logger.info "Received stop_consumer message but consumer is not running"
+      Logger.info log_msg("received :stop_cosumer but already stopped", state)
       {:noreply, state}
     end
   end
 
   def handle_info({:connected, connection}, state = %Worker{}) do
     # Declares queue
-    state.job.declare_queue(state.host)
+    Queue.declare_with_retry(state.host, state.queue)
 
     # Consumes the queue
-    case Consumer.consume(connection, state.job.queue_name(), state.concurrency) do
+    case Consumer.consume(connection, state.queue, state.concurrency) do
       {channel, consumer_tag} ->
-        Logger.info "TaskBunny.Worker: start consuming #{inspect state.job}. PID: #{inspect self()}"
+        Logger.info log_msg("start comsuming", state)
         {:noreply, %{state | channel: channel, consumer_tag: consumer_tag}}
       error ->
         {:stop, {:failed_to_consume, error}, state}
@@ -143,12 +140,13 @@ defmodule TaskBunny.Worker do
   def handle_info({:basic_deliver, body, meta}, state) do
     case Message.decode(body) do
       {:ok, decoded} ->
-        Logger.debug "TaskBunny.Worker:(#{state.job}) basic_deliver with #{inspect body} on #{inspect self()}"
-        JobRunner.invoke(state.job, decoded["payload"], {body, meta})
+        Logger.debug log_msg("bacic_deliver", state, [body: body])
+
+        JobRunner.invoke(decoded["job"], decoded["payload"], {body, meta})
 
         {:noreply, %{state | runners: state.runners + 1}}
       error ->
-        Logger.error "TaskBunny.Worker:(#{state.job}) basic_deliver with invalid (#{inspect error}) payload: (#{inspect body} on #{inspect self()}"
+        Logger.error log_msg("bacic_deliver invalid body", state, [body: body, error: error])
 
         reject_message(state, body, meta)
 
@@ -163,7 +161,7 @@ defmodule TaskBunny.Worker do
   Acknowledge to RabbitMQ.
   """
   def handle_info({:job_finished, result, {body, meta}}, state) do
-    Logger.debug "TaskBunny.Worker:(#{state.job}) job_finished with #{inspect body} on #{inspect self()} with meta #{inspect meta}"
+    Logger.debug log_msg("job_finished", state, [body: body, meta: meta])
     case succeeded?(result) do
       true ->
         Consumer.ack(state.channel, meta, true)
@@ -182,11 +180,11 @@ defmodule TaskBunny.Worker do
     channel =
       case state.channel do
         nil -> false
-        _channel -> "#{state.job.queue_name} (#{state.consumer_tag})"
+        _channel -> "#{state.queue} (#{state.consumer_tag})"
       end
 
     status = %TaskBunny.Status.Worker{
-      job: state.job,
+      queue: state.queue,
       runners: state.runners,
       channel: channel,
       stats: state.job_stats,
@@ -196,9 +194,9 @@ defmodule TaskBunny.Worker do
     {:reply, status, state}
   end
 
-  @spec pname(job :: atom) :: atom
-  defp pname(job) do
-    String.to_atom("TaskBunny.Worker.#{job}")
+  @spec pname(String.t) :: atom
+  defp pname(queue) do
+    String.to_atom("TaskBunny.Worker.#{queue}")
   end
 
   @spec update_job_stats(Worker.t, :succeeded | :failed | :rejected) :: Worker.t
@@ -218,19 +216,21 @@ defmodule TaskBunny.Worker do
   defp succeeded?(_), do: false
 
   defp handle_failed_job(state, body, meta, result) do
-    failed_count = Message.failed_count(body)
+    {:ok, decoded} = Message.decode(body)
+    failed_count = Message.failed_count(decoded)
+    job = decoded["job"]
     new_body = Message.add_error_log(body, result)
 
-    case failed_count < state.job.max_retry() do
+    case failed_count < job.max_retry() do
       true ->
-        Logger.warn "TaskBunny.Worker - job failed #{failed_count + 1} times. TaskBunny will retry the job. JOB: #{inspect state.job}. MESSAGE: #{inspect body}. ERROR: #{inspect result}"
+        Logger.warn log_msg("job failed #{failed_count + 1} times.", state, [body: body, will_be_retried: true])
 
-        retry_message(state, new_body, meta)
+        retry_message(job, state, new_body, meta)
 
         {:noreply, update_job_stats(state, :failed)}
       false ->
         # Failed more than X times
-        Logger.error "TaskBunny.Worker - job failed #{failed_count + 1} times. TaskBunny stops retrying the job. JOB: #{inspect state.job}. PAYLOAD: #{inspect body}. ERROR: #{inspect result}"
+        Logger.error log_msg("job failed #{failed_count + 1} times.", state, [body: body, will_be_retried: false])
 
         reject_message(state, new_body, meta)
 
@@ -238,10 +238,9 @@ defmodule TaskBunny.Worker do
     end
   end
 
-  @spec retry_message(Worker.t, any, any) :: :ok
-  defp retry_message(state, body, meta) do
-    job = state.job
-    retry_queue = Queue.retry_queue_name(job.queue_name())
+  @spec retry_message(atom, Worker.t, any, any) :: :ok
+  defp retry_message(job, state, body, meta) do
+    retry_queue = Queue.retry_queue_name(state.queue)
     options = [
       expiration: "#{job.retry_interval()}"
     ]
@@ -253,10 +252,19 @@ defmodule TaskBunny.Worker do
 
   @spec reject_message(Worker.t, any, any) :: :ok
   defp reject_message(state, body, meta) do
-    rejected_queue = Queue.rejected_queue_name(state.job.queue_name())
+    rejected_queue = Queue.rejected_queue_name(state.queue)
     Publisher.publish(state.host, rejected_queue, body)
 
     Consumer.ack(state.channel, meta, true)
     :ok
+  end
+
+  defp log_msg(message, state, additional \\ nil) do
+    message = "TaskBunny.Worker: #{message}. Queue: #{state.queue}. Concurrency: #{state.concurrency}. PID: #{inspect self()}."
+    if additional do
+      "#{message} #{inspect additional}"
+    else
+      message
+    end
   end
 end

--- a/lib/task_bunny/worker_supervisor.ex
+++ b/lib/task_bunny/worker_supervisor.ex
@@ -8,25 +8,23 @@ defmodule TaskBunny.WorkerSupervisor do
   """
 
   use Supervisor
-
-  alias TaskBunny.Worker
+  alias TaskBunny.{Config, Worker}
 
   @type jobs :: list({host :: atom, job :: atom, concurrenct :: integer})
 
-  @spec start_link(jobs, atom) :: {:ok, pid} | {:error, term}
-  def start_link(jobs, name \\ __MODULE__) do
-    Supervisor.start_link(__MODULE__, jobs, name: name)
+  @spec start_link(atom) :: {:ok, pid} | {:error, term}
+  def start_link(name \\ __MODULE__) do
+    Supervisor.start_link(__MODULE__, [], name: name)
   end
 
-  @spec init(jobs) :: {:ok, {:supervisor.sup_flags, [Supervisor.Spec.spec]}} | :ignore
-  def init(jobs) do
-    jobs
-    |> Enum.filter(fn ({_, job, _}) -> Code.ensure_loaded?(job) end)
-    |> Enum.map(fn ({host, job, concurrency}) ->
+  @spec init(list) :: {:ok, {:supervisor.sup_flags, [Supervisor.Spec.spec]}} | :ignore
+  def init([]) do
+    Config.workers
+    |> Enum.map(fn (config) ->
          worker(
           Worker,
-          [{host, job, concurrency}],
-          id: "task_bunny.worker.#{job.queue_name}"
+          [config],
+          id: "task_bunny.worker.#{config[:queue]}"
         )
        end)
     |> supervise(strategy: :one_for_one)

--- a/lib/task_bunny/worker_supervisor.ex
+++ b/lib/task_bunny/worker_supervisor.ex
@@ -19,7 +19,7 @@ defmodule TaskBunny.WorkerSupervisor do
 
   @spec init(list) :: {:ok, {:supervisor.sup_flags, [Supervisor.Spec.spec]}} | :ignore
   def init([]) do
-    Config.workers
+    Config.workers()
     |> Enum.map(fn (config) ->
          worker(
           Worker,

--- a/lib/task_bunny/worker_supervisor.ex
+++ b/lib/task_bunny/worker_supervisor.ex
@@ -62,7 +62,7 @@ defmodule TaskBunny.WorkerSupervisor do
   @doc """
   Similar to graceful_halt/2 but gets pid from module name.
   """
-  @spec graceful_halt(pid, integer) :: :ok | {:error, any}
+  @spec graceful_halt(integer) :: :ok | {:error, any}
   def graceful_halt(timeout) do
     pid = Process.whereis(__MODULE__)
     graceful_halt(pid, timeout)

--- a/test/support/queue_helper.ex
+++ b/test/support/queue_helper.ex
@@ -43,10 +43,6 @@ defmodule TaskBunny.TestSupport.QueueHelper do
     :ok
   end
 
-  def purge(job, host) do
-    purge(job.queue_name, host)
-  end
-
   def pop(queue) do
     {:ok, channel} = open_channel()
 

--- a/test/task_bunny/config_test.exs
+++ b/test/task_bunny/config_test.exs
@@ -2,50 +2,60 @@ defmodule TaskBunny.ConfigTest do
   use ExUnit.Case, async: false
   alias TaskBunny.Config
 
-  describe "jobs" do
-    defmodule SampleJobs do
-      defmodule HelloJob do
-        use TaskBunny.Job
-        def perform(_payload), do: nil
-      end
-      defmodule HolaJob do
-        use TaskBunny.Job
-        def perform(_payload), do: nil
-      end
-      defmodule CiaoJob do
-        use TaskBunny.Job
-        def perform(_payload), do: nil
-      end
-    end
-
-    setup do
-      envs = [
-        jobs: [
-          [job: SampleJobs.HelloJob, concurrency: 5],
-          [job: SampleJobs.HolaJob, concurrency: 2]
-        ],
-        extra_jobs: [
-          [job: SampleJobs.CiaoJob, concurrency: 3]
-        ],
-        included_applications: [],
-        hosts: [default: [connect_options: "amqp://localhost"]]
+  defp test_config do
+    [
+      queue: [
+        namespace: "test.",
+        queues: [
+          [name: "high", worker: [concurrency: 10], jobs: ["High.*"]],
+          [name: "normal", jobs: :default],
+          [name: "low", worker: false, jobs: [SlowJob]]
+        ]
+      ],
+      extra_queue: [
+        namespace: "extra.",
+        queues: [
+          [name: "queue1", worker: [concurrency: 1], jobs: ["Extra.*"], host: :extra]
+        ]
       ]
+    ]
+  end
 
-      :meck.new Application, [:passthrough]
-      :meck.expect Application, :get_all_env, fn (:task_bunny) -> envs end
+  setup do
+    :meck.new Application, [:passthrough]
+    :meck.expect Application, :get_all_env, fn (:task_bunny) -> test_config() end
 
-      on_exit(fn -> :meck.unload end)
+    on_exit(fn -> :meck.unload end)
 
-      :ok
+    :ok
+  end
+
+  describe "queues" do
+    test "combines all queue configs and sets namespace" do
+      queue_names = Config.queues
+                    |> Enum.map(fn (queue) -> queue[:name] end)
+
+      assert queue_names == ["test.high", "test.normal", "test.low", "extra.queue1"]
     end
+  end
 
-    test "merges all jobs" do
-      all_jobs = [
-        [job: SampleJobs.HelloJob, concurrency: 5],
-        [job: SampleJobs.HolaJob, concurrency: 2],
-        [job: SampleJobs.CiaoJob, concurrency: 3]
+  describe "workers" do
+    test "lists up information for workers" do
+      assert Config.workers == [
+        [queue: "test.high", concurrency: 10, host: :default],
+        [queue: "test.normal", concurrency: 2, host: :default],
+        [queue: "extra.queue1", concurrency: 1, host: :extra]
       ]
-      assert Config.jobs == all_jobs
+    end
+  end
+
+  describe "queue_for_job" do
+    test "returns matched queue" do
+      assert Config.queue_for_job(High.TestJob) == "test.high"
+      assert Config.queue_for_job(SlowJob) == "test.low"
+      assert Config.queue_for_job(SampleJob) == "test.normal"
+      assert Config.queue_for_job(Extra.TestJob) == "extra.queue1"
+      assert Config.queue_for_job(Foo.High.TestJob) == "test.normal"
     end
   end
 end

--- a/test/task_bunny/job_test.exs
+++ b/test/task_bunny/job_test.exs
@@ -1,27 +1,9 @@
 defmodule TaskBunny.JobTest do
   use ExUnit.Case
   import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Job, Message, TestSupport.QueueHelper}
+  alias TaskBunny.{Job, Queue, Message, TestSupport.QueueHelper}
 
-  defmodule JobWithAllDefault do
-    use Job
-    def perform(_), do: nil
-  end
-
-  defmodule JobWithId do
-    use Job, id: "frank"
-    def perform(_), do: nil
-  end
-
-  defmodule JobWithNamespace do
-    use Job, namespace: "frank"
-    def perform(_), do: nil
-  end
-
-  defmodule JobWithFull do
-    use Job, full: true
-    def perform(_), do: nil
-  end
+  @queue "task_bunny.job_test"
 
   defmodule TestJob do
     use Job
@@ -29,35 +11,17 @@ defmodule TaskBunny.JobTest do
   end
 
   setup do
-    clean(TestJob.all_queues())
+    clean(Queue.queue_with_subqueues(@queue))
 
     :ok
-  end
-
-  describe "queue_name" do
-    test "has default name" do
-      assert JobWithAllDefault.queue_name == "jobs.job_with_all_default"
-    end
-
-    test "has id" do
-      assert JobWithId.queue_name == "jobs.frank"
-    end
-
-    test "has namespace" do
-      assert JobWithNamespace.queue_name == "frank.job_with_namespace"
-    end
-
-    test "has full namespace" do
-      assert JobWithFull.queue_name == "jobs.task_bunny.job_test.job_with_full"
-    end
   end
 
   describe "enqueue" do
     test "enqueues job" do
       payload = %{"foo" => "bar"}
-      :ok = TestJob.enqueue(payload)
+      :ok = TestJob.enqueue(payload, queue: @queue)
 
-      {received, _} = QueueHelper.pop(TestJob.queue_name())
+      {received, _} = QueueHelper.pop(@queue)
       {:ok, %{"payload" => received_payload}} = Message.decode(received)
       assert received_payload == payload
     end

--- a/test/task_bunny/status/worker_test.exs
+++ b/test/task_bunny/status/worker_test.exs
@@ -2,13 +2,15 @@ defmodule TaskBunny.Status.WorkerTest do
   use ExUnit.Case, async: false
 
   import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.Config
+  alias TaskBunny.{Config, Queue}
   alias TaskBunny.TestSupport.JobTestHelper
   alias TaskBunny.TestSupport.JobTestHelper.TestJob
 
   @host :worker_test
   @supervisor :worker_test_supervisor
   @worker_supervisor :worker_test_worker_supervisor
+  @queue1 "task_bunny.status.worker_test1"
+  @queue2 "task_bunny.status.worker_test2"
 
   defmodule RejectJob do
     use TaskBunny.Job
@@ -23,34 +25,31 @@ defmodule TaskBunny.Status.WorkerTest do
     def max_retry, do: 0
   end
 
-  defp find_worker(workers, job_search) do
-    Enum.find(workers, fn %{job: job} -> job == job_search end)
+  defp find_worker(workers, queue) do
+    Enum.find(workers, fn %{queue: w_queue} -> queue == w_queue end)
   end
 
-  defp setup_config do
-    jobs = [
-      [
-        job: TestJob,
-        concurrency: 3,
-        host: @host,
-      ],
-      [
-        job: RejectJob,
-        concurrency: 3,
-        host: @host,
-      ],
+  defp all_queues do
+    [@queue1] ++ Queue.sub_queues(@queue1) ++
+    [@queue2] ++ Queue.sub_queues(@queue2)
+  end
+
+  defp mock_config do
+    workers = [
+      [host: @host, queue: @queue1, concurrency: 3],
+      [host: @host, queue: @queue2, concurrency: 3]
     ]
 
     :meck.new Config, [:passthrough]
     :meck.expect Config, :hosts, fn -> [@host] end
     :meck.expect Config, :connect_options, fn (@host) -> "amqp://localhost" end
-    :meck.expect Config, :jobs, fn -> jobs end
+    :meck.expect Config, :workers, fn -> workers end
   end
 
   setup do
-    clean(TestJob.all_queues())
+    clean(all_queues())
 
-    setup_config()
+    mock_config()
     JobTestHelper.setup()
 
     TaskBunny.Supervisor.start_link(@supervisor, @worker_supervisor)
@@ -75,13 +74,13 @@ defmodule TaskBunny.Status.WorkerTest do
     test "running with jobs being performed" do
       payload = %{"sleep" => 10_000}
 
-      TestJob.enqueue(payload, host: @host)
-      TestJob.enqueue(payload, host: @host)
+      TestJob.enqueue(payload, host: @host, queue: @queue1)
+      TestJob.enqueue(payload, host: @host, queue: @queue1)
 
       JobTestHelper.wait_for_perform(2)
 
       %{workers: workers} = TaskBunny.Status.overview(@supervisor)
-      %{runners: runner_count} = find_worker(workers, TestJob)
+      %{runners: runner_count} = find_worker(workers, @queue1)
 
       assert runner_count == 2
     end
@@ -91,11 +90,11 @@ defmodule TaskBunny.Status.WorkerTest do
     test "jobs succeeded" do
       payload = %{"hello" => "world1"}
 
-      TestJob.enqueue(payload)
+      TestJob.enqueue(payload, host: @host, queue: @queue1)
       JobTestHelper.wait_for_perform()
 
       %{workers: workers} = TaskBunny.Status.overview(@supervisor)
-      %{stats: stats} = find_worker(workers, TestJob)
+      %{stats: stats} = find_worker(workers, @queue1)
 
       assert stats.succeeded == 1
     end
@@ -103,11 +102,11 @@ defmodule TaskBunny.Status.WorkerTest do
     test "jobs failed" do
       payload = %{"fail" => "fail"}
 
-      TestJob.enqueue(payload)
+      TestJob.enqueue(payload, host: @host, queue: @queue1)
       JobTestHelper.wait_for_perform()
 
       %{workers: workers} = TaskBunny.Status.overview(@supervisor)
-      %{stats: stats} = find_worker(workers, TestJob)
+      %{stats: stats} = find_worker(workers, @queue1)
 
       assert stats.failed == 1
     end
@@ -115,11 +114,11 @@ defmodule TaskBunny.Status.WorkerTest do
     test "jobs rejected" do
       payload = %{"fail" => "fail"}
 
-      RejectJob.enqueue(payload)
+      RejectJob.enqueue(payload, host: @host, queue: @queue2)
       JobTestHelper.wait_for_perform()
 
       %{workers: workers} = TaskBunny.Status.overview(@supervisor)
-      %{stats: stats} = find_worker(workers, RejectJob)
+      %{stats: stats} = find_worker(workers, @queue2)
 
       assert stats.rejected == 1
     end

--- a/test/task_bunny/status/worker_test.exs
+++ b/test/task_bunny/status/worker_test.exs
@@ -30,8 +30,8 @@ defmodule TaskBunny.Status.WorkerTest do
   end
 
   defp all_queues do
-    [@queue1] ++ Queue.sub_queues(@queue1) ++
-    [@queue2] ++ Queue.sub_queues(@queue2)
+    Queue.queue_with_subqueues(@queue1) ++
+    Queue.queue_with_subqueues(@queue2)
   end
 
   defp mock_config do

--- a/test/task_bunny/status_test.exs
+++ b/test/task_bunny/status_test.exs
@@ -11,10 +11,6 @@ defmodule TaskBunny.StatusTest do
   @supervisor :status_test_supervisor
   @worker_supervisor :status_test_worker_supervisor
 
-  defp all_queues do
-    [@queue] ++ Queue.sub_queues(@queue)
-  end
-
   defp mock_config do
     worker = [host: @host, queue: @queue, concurrency: 1]
 
@@ -25,7 +21,7 @@ defmodule TaskBunny.StatusTest do
   end
 
   setup do
-    clean(all_queues())
+    clean(Queue.queue_with_subqueues(@queue))
 
     mock_config()
 

--- a/test/task_bunny/supervisor_test.exs
+++ b/test/task_bunny/supervisor_test.exs
@@ -3,21 +3,22 @@ defmodule TaskBunny.SupervisorTest do
   import TaskBunny.TestSupport.QueueHelper
   alias TaskBunny.TestSupport.JobTestHelper
   alias TaskBunny.TestSupport.JobTestHelper.TestJob
-  alias TaskBunny.{Config, Connection}
+  alias TaskBunny.{Config, Connection, Queue}
 
   @host :sv_test
+  @queue "task_bunny.supervisor_test"
 
-  defp setup_config do
-    job = [
-      job: TaskBunny.TestSupport.JobTestHelper.TestJob,
-      concurrency: 1,
-      host: @host
-    ]
+  defp all_queues do
+    [@queue] ++ Queue.sub_queues(@queue)
+  end
+
+  defp mock_config do
+    worker = [host: @host, queue: @queue, concurrency: 1]
 
     :meck.new Config, [:passthrough]
     :meck.expect Config, :hosts, fn -> [@host] end
     :meck.expect Config, :connect_options, fn (@host) -> "amqp://localhost" end
-    :meck.expect Config, :jobs, fn -> [job] end
+    :meck.expect Config, :workers, fn -> [worker] end
   end
 
   defp wait_for_process_died(pid) do
@@ -43,9 +44,9 @@ defmodule TaskBunny.SupervisorTest do
   end
 
   setup do
-    clean(TestJob.all_queues())
+    clean(all_queues())
 
-    setup_config()
+    mock_config()
     JobTestHelper.setup()
 
     TaskBunny.Supervisor.start_link(:supevisor_test, :wsv_supervisor_test)
@@ -60,7 +61,7 @@ defmodule TaskBunny.SupervisorTest do
 
   test "starts connection and worker" do
     payload = %{"hello" => "world"}
-    TestJob.enqueue(payload, host: @host)
+    TestJob.enqueue(payload, host: @host, queue: @queue)
 
     JobTestHelper.wait_for_perform
     assert List.first(JobTestHelper.performed_payloads) == payload
@@ -69,7 +70,7 @@ defmodule TaskBunny.SupervisorTest do
   describe "AMQP connection is lost" do
     test "recovers by restarting connection and all workers" do
       conn_name = :"TaskBunny.Connection.#{@host}"
-      work_name = :"TaskBunny.Worker.Elixir.TaskBunny.TestSupport.JobTestHelper.TestJob"
+      work_name = :"TaskBunny.Worker.#{@queue}"
       conn_pid = Process.whereis(conn_name)
       work_pid = Process.whereis(work_name)
 
@@ -88,7 +89,7 @@ defmodule TaskBunny.SupervisorTest do
 
       # Make sure worker handles the job
       payload = %{"hello" => "world"}
-      TestJob.enqueue(payload, host: @host)
+      TestJob.enqueue(payload, host: @host, queue: @queue)
 
       JobTestHelper.wait_for_perform()
       assert List.first(JobTestHelper.performed_payloads) == payload
@@ -98,7 +99,7 @@ defmodule TaskBunny.SupervisorTest do
   describe "a worker crashes" do
     test "restarts the worker but connection stays" do
       conn_name = :"TaskBunny.Connection.#{@host}"
-      work_name = :"TaskBunny.Worker.Elixir.TaskBunny.TestSupport.JobTestHelper.TestJob"
+      work_name = :"TaskBunny.Worker.#{@queue}"
       conn_pid = Process.whereis(conn_name)
       work_pid = Process.whereis(work_name)
 

--- a/test/task_bunny/supervisor_test.exs
+++ b/test/task_bunny/supervisor_test.exs
@@ -8,10 +8,6 @@ defmodule TaskBunny.SupervisorTest do
   @host :sv_test
   @queue "task_bunny.supervisor_test"
 
-  defp all_queues do
-    [@queue] ++ Queue.sub_queues(@queue)
-  end
-
   defp mock_config do
     worker = [host: @host, queue: @queue, concurrency: 1]
 
@@ -44,7 +40,7 @@ defmodule TaskBunny.SupervisorTest do
   end
 
   setup do
-    clean(all_queues())
+    clean(Queue.queue_with_subqueues(@queue))
 
     mock_config()
     JobTestHelper.setup()

--- a/test/task_bunny/worker_supervisor_test.exs
+++ b/test/task_bunny/worker_supervisor_test.exs
@@ -8,10 +8,6 @@ defmodule TaskBunny.WorkerSupervisorTest do
   @queue "task_bunny.worker_supervisor_test"
   @worker_name :"TaskBunny.Worker.#{@queue}"
 
-  defp all_queues do
-    [@queue] ++ Queue.sub_queues(@queue)
-  end
-
   defp workers do
     [
       [queue: @queue, concurrency: 1, host: :default]
@@ -38,7 +34,7 @@ defmodule TaskBunny.WorkerSupervisorTest do
   end
 
   setup do
-    clean(all_queues())
+    clean(Queue.queue_with_subqueues(@queue))
     JobTestHelper.setup
 
     :meck.new Config, [:passthrough]

--- a/test/task_bunny/worker_supervisor_test.exs
+++ b/test/task_bunny/worker_supervisor_test.exs
@@ -1,30 +1,29 @@
 defmodule TaskBunny.WorkerSupervisorTest do
   use ExUnit.Case, async: false
   import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Connection, Queue, WorkerSupervisor}
+  alias TaskBunny.{Config, Connection, Queue, WorkerSupervisor}
   alias TaskBunny.TestSupport.JobTestHelper
   alias TaskBunny.TestSupport.JobTestHelper.TestJob
 
-  @test_job_worker :"TaskBunny.Worker.Elixir.TaskBunny.TestSupport.JobTestHelper.TestJob"
+  @queue "task_bunny.worker_supervisor_test"
+  @worker_name :"TaskBunny.Worker.#{@queue}"
 
-  setup do
-    clean(TestJob.all_queues())
-    JobTestHelper.setup
+  defp all_queues do
+    [@queue] ++ Queue.sub_queues(@queue)
+  end
 
-    on_exit fn ->
-      JobTestHelper.teardown
-    end
-
-    :ok
+  defp workers do
+    [
+      [queue: @queue, concurrency: 1, host: :default]
+    ]
   end
 
   defp start_worker_supervisor do
-    jobs = [{:default, TestJob, 3}]
-    {:ok, pid} = WorkerSupervisor.start_link(jobs, :woker_supervisor_test)
+    {:ok, pid} = WorkerSupervisor.start_link(:worker_superrvisor_test)
     pid
   end
 
-  defp wait_for_worker_up(name \\ @test_job_worker) do
+  defp wait_for_worker_up(name \\ @worker_name) do
     Enum.find_value 1..100, fn (_) ->
       if pid = Process.whereis(name) do
         %{consuming: consuming} = GenServer.call(pid, :status)
@@ -38,13 +37,27 @@ defmodule TaskBunny.WorkerSupervisorTest do
     end
   end
 
+  setup do
+    clean(all_queues())
+    JobTestHelper.setup
+
+    :meck.new Config, [:passthrough]
+    :meck.expect Config, :workers, fn () -> workers() end
+
+    on_exit fn ->
+      JobTestHelper.teardown
+    end
+
+    :ok
+  end
+
   test "starts job worker" do
     pid = start_worker_supervisor()
     %{active: active} = Supervisor.count_children(pid)
     assert active == 1
 
     payload = %{"hello" => "world"}
-    TestJob.enqueue(payload)
+    TestJob.enqueue(payload, queue: @queue)
 
     JobTestHelper.wait_for_perform()
     assert List.first(JobTestHelper.performed_payloads) == payload
@@ -60,13 +73,13 @@ defmodule TaskBunny.WorkerSupervisorTest do
       assert WorkerSupervisor.graceful_halt(pid, 1000) == :ok
 
       payload = %{"hello" => "world2"}
-      TestJob.enqueue(payload)
+      TestJob.enqueue(payload, queue: @queue)
       :timer.sleep(50)
 
       assert JobTestHelper.performed_count() == 0
 
       %{message_count: count} = Queue.state(
-        Connection.get_connection(), TestJob.queue_name()
+        Connection.get_connection(), @queue
       )
 
       assert count == 1
@@ -77,7 +90,7 @@ defmodule TaskBunny.WorkerSupervisorTest do
       wait_for_worker_up()
 
       payload = %{"sleep" => 60_000}
-      TestJob.enqueue(payload)
+      TestJob.enqueue(payload, queue: @queue)
       JobTestHelper.wait_for_perform()
 
       assert {:error, _} = WorkerSupervisor.graceful_halt(pid, 100)
@@ -88,7 +101,7 @@ defmodule TaskBunny.WorkerSupervisorTest do
       wait_for_worker_up()
 
       payload = %{"sleep" => 200}
-      TestJob.enqueue(payload)
+      TestJob.enqueue(payload, queue: @queue)
       JobTestHelper.wait_for_perform()
 
       assert :ok = WorkerSupervisor.graceful_halt(pid, 1000)

--- a/test/task_bunny/worker_test.exs
+++ b/test/task_bunny/worker_test.exs
@@ -9,6 +9,15 @@ defmodule TaskBunny.WorkerTest do
 
   @queue "task_bunny.worker_test"
 
+  defp all_queues do
+    [@queue] ++ Queue.sub_queues(@queue)
+  end
+
+  defp start_worker(concurrency \\ 1) do
+    {:ok, worker} = Worker.start_link(queue: @queue, concurrency: concurrency)
+    worker
+  end
+
   setup do
     clean(all_queues())
 
@@ -19,15 +28,6 @@ defmodule TaskBunny.WorkerTest do
     end
 
     :ok
-  end
-
-  defp all_queues do
-    [@queue] ++ Queue.sub_queues(@queue)
-  end
-
-  defp start_worker(concurrency \\ 1) do
-    {:ok, worker} = Worker.start_link(queue: @queue, concurrency: concurrency)
-    worker
   end
 
   describe "worker" do

--- a/test/task_bunny/worker_test.exs
+++ b/test/task_bunny/worker_test.exs
@@ -10,7 +10,7 @@ defmodule TaskBunny.WorkerTest do
   @queue "task_bunny.worker_test"
 
   defp all_queues do
-    [@queue] ++ Queue.sub_queues(@queue)
+    Queue.queue_with_subqueues(@queue)
   end
 
   defp start_worker(concurrency \\ 1) do
@@ -20,7 +20,6 @@ defmodule TaskBunny.WorkerTest do
 
   setup do
     clean(all_queues())
-
     JobTestHelper.setup
 
     on_exit fn ->


### PR DESCRIPTION
Decoupling queues from jobs. Now you can share queue with multiple jobs. It requires you to update your config.

See [the github issue](https://github.com/shinyscorpion/task_bunny/issues/4) for the details.

- [x] new configuration
- [x] fix `Job.enqueue/2`, update `Job.queue_name/0' and remove queue concerns from Job
- [x] worker to take new configuration and get job from message
- [x] fix implications by worker changes (supervisor, worker_supervisor and state)
- [x] fix mix task
- [x] ~retry_interval to take retry_count~ > separate PR
- [x] update README