### PR TITLE
Rename test helpers and fix the implications

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ defmodule SampleJob do
   end
 
   def max_retry, do: 100
-  def retry_interval, do: 10_000
+  def retry_interval(_), do: 10_000
 end
 
 ```
@@ -189,6 +189,20 @@ In this example, it will retry 100 times for every 10 seconds.
 If a job fails more than `max_retry` times, the payload is sent to `jobs.[job_name].rejected` queue.
 
 Under the hood, TaskBunny uses [dead letter exchanges](https://www.rabbitmq.com/dlx.html) to support retry.
+
+You can also change the retry_interval by the number of failures.
+
+```elixir
+  def max_retry, do: 5
+
+  def retry_interval(failed_count) do
+    # failed_count will be between 1 and 5.
+    # Gradually have longer retry interval
+    [10, 60, 300, 3_600, 7_200]
+    |> Enum.map(&(&1 * 1000))
+    |> Enum.at(failed_count - 1, 1000)
+  end
+```
 
 ### Timeout
 

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -54,9 +54,9 @@ defmodule TaskBunny.Job do
       # Retries 10 times in every 5 minutes in default.
       # You have to re-create the queue after you change retry_interval.
       def max_retry, do: 10
-      def retry_interval, do: 300_000
+      def retry_interval(_failed_count), do: 300_000
 
-      defoverridable [timeout: 0, max_retry: 0, retry_interval: 0]
+      defoverridable [timeout: 0, max_retry: 0, retry_interval: 1]
     end
   end
 end

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -22,7 +22,7 @@ defmodule TaskBunny.JobTestHelper do
       end
     end
 
-    def retry_interval, do: RetryInterval.interval()
+    def retry_interval(_), do: RetryInterval.interval()
   end
 
   def wait_for_perform(number \\ 1) do

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -1,4 +1,4 @@
-defmodule TaskBunny.TestSupport.JobTestHelper do
+defmodule TaskBunny.JobTestHelper do
   defmodule Tracer do
     def performed(_), do: nil
   end

--- a/test/support/queue_test_helper.ex
+++ b/test/support/queue_test_helper.ex
@@ -1,4 +1,4 @@
-defmodule TaskBunny.TestSupport.QueueHelper do
+defmodule TaskBunny.QueueTestHelper do
   defmacro clean(queues) do
     quote do
       # Remove pre-existing queues before every test.

--- a/test/task_bunny/job_test.exs
+++ b/test/task_bunny/job_test.exs
@@ -1,7 +1,7 @@
 defmodule TaskBunny.JobTest do
   use ExUnit.Case
-  import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Job, Queue, Message, TestSupport.QueueHelper}
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Job, Queue, Message, QueueTestHelper}
 
   @queue "task_bunny.job_test"
 
@@ -21,7 +21,7 @@ defmodule TaskBunny.JobTest do
       payload = %{"foo" => "bar"}
       :ok = TestJob.enqueue(payload, queue: @queue)
 
-      {received, _} = QueueHelper.pop(@queue)
+      {received, _} = QueueTestHelper.pop(@queue)
       {:ok, %{"payload" => received_payload}} = Message.decode(received)
       assert received_payload == payload
     end

--- a/test/task_bunny/publisher_test.exs
+++ b/test/task_bunny/publisher_test.exs
@@ -1,7 +1,7 @@
 defmodule TaskBunny.PublisherTest do
   use ExUnit.Case, async: false
-  import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Publisher,TestSupport.QueueHelper}
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Publisher, QueueTestHelper}
 
   @queue_name "task_bunny.test_queue"
 
@@ -13,10 +13,10 @@ defmodule TaskBunny.PublisherTest do
 
   describe "publish" do
     test "publishes a message to a queue" do
-      QueueHelper.declare(@queue_name)
+      QueueTestHelper.declare(@queue_name)
       Publisher.publish(:default, @queue_name, "Hello Queue")
 
-      {message, _} = QueueHelper.pop(@queue_name)
+      {message, _} = QueueTestHelper.pop(@queue_name)
       assert message == "Hello Queue"
     end
   end

--- a/test/task_bunny/status/worker_test.exs
+++ b/test/task_bunny/status/worker_test.exs
@@ -1,10 +1,9 @@
 defmodule TaskBunny.Status.WorkerTest do
   use ExUnit.Case, async: false
 
-  import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Config, Queue}
-  alias TaskBunny.TestSupport.JobTestHelper
-  alias TaskBunny.TestSupport.JobTestHelper.TestJob
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Config, Queue, JobTestHelper}
+  alias JobTestHelper.TestJob
 
   @host :worker_test
   @supervisor :worker_test_supervisor

--- a/test/task_bunny/status_test.exs
+++ b/test/task_bunny/status_test.exs
@@ -1,9 +1,8 @@
 defmodule TaskBunny.StatusTest do
   use ExUnit.Case, async: false
 
-  import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Config, Queue}
-  alias TaskBunny.TestSupport.JobTestHelper
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Config, Queue, JobTestHelper}
 
   @host :status_test
   @queue "task_bunny.status_test"
@@ -24,9 +23,7 @@ defmodule TaskBunny.StatusTest do
     clean(Queue.queue_with_subqueues(@queue))
 
     mock_config()
-
     JobTestHelper.setup
-
     TaskBunny.Supervisor.start_link(@supervisor, @worker_supervisor)
 
     on_exit fn ->

--- a/test/task_bunny/supervisor_test.exs
+++ b/test/task_bunny/supervisor_test.exs
@@ -1,9 +1,8 @@
 defmodule TaskBunny.SupervisorTest do
   use ExUnit.Case, async: false
-  import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.TestSupport.JobTestHelper
-  alias TaskBunny.TestSupport.JobTestHelper.TestJob
-  alias TaskBunny.{Config, Connection, Queue}
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Config, Connection, Queue, JobTestHelper}
+  alias JobTestHelper.TestJob
 
   @host :sv_test
   @queue "task_bunny.supervisor_test"

--- a/test/task_bunny/worker_supervisor_test.exs
+++ b/test/task_bunny/worker_supervisor_test.exs
@@ -1,9 +1,8 @@
 defmodule TaskBunny.WorkerSupervisorTest do
   use ExUnit.Case, async: false
-  import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Config, Connection, Queue, WorkerSupervisor}
-  alias TaskBunny.TestSupport.JobTestHelper
-  alias TaskBunny.TestSupport.JobTestHelper.TestJob
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Config, Connection, Queue, WorkerSupervisor, JobTestHelper}
+  alias JobTestHelper.TestJob
 
   @queue "task_bunny.worker_supervisor_test"
   @worker_name :"TaskBunny.Worker.#{@queue}"

--- a/test/task_bunny/worker_test.exs
+++ b/test/task_bunny/worker_test.exs
@@ -1,11 +1,8 @@
 defmodule TaskBunny.WorkerTest do
   use ExUnit.Case, async: false
-  import TaskBunny.TestSupport.QueueHelper
-  alias TaskBunny.{Connection, Worker, Queue}
-  alias TaskBunny.TestSupport.{
-    JobTestHelper,
-    JobTestHelper.TestJob
-  }
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Connection, Worker, Queue, JobTestHelper}
+  alias JobTestHelper.TestJob
 
   @queue "task_bunny.worker_test"
 


### PR DESCRIPTION
`TestSupport` is unnecessary namespace that makes code readability worse. Also have consistent rule on test helper: `*TestHelper`. Applying it to `QueueTestHelper` and `JobTestHelper`.