### PR TITLE
Retry interval with failed count

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ defmodule SampleJob do
   end
 
   def max_retry, do: 100
-  def retry_interval, do: 10_000
+  def retry_interval(_), do: 10_000
 end
 
 ```
@@ -189,6 +189,20 @@ In this example, it will retry 100 times for every 10 seconds.
 If a job fails more than `max_retry` times, the payload is sent to `jobs.[job_name].rejected` queue.
 
 Under the hood, TaskBunny uses [dead letter exchanges](https://www.rabbitmq.com/dlx.html) to support retry.
+
+You can also change the retry_interval by the number of failures.
+
+```elixir
+  def max_retry, do: 5
+
+  def retry_interval(failed_count) do
+    # failed_count will be between 1 and 5.
+    # Gradually have longer retry interval
+    [10, 60, 300, 3_600, 7_200]
+    |> Enum.map(&(&1 * 1000))
+    |> Enum.at(failed_count - 1, 1000)
+  end
+```
 
 ### Timeout
 

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -54,9 +54,9 @@ defmodule TaskBunny.Job do
       # Retries 10 times in every 5 minutes in default.
       # You have to re-create the queue after you change retry_interval.
       def max_retry, do: 10
-      def retry_interval, do: 300_000
+      def retry_interval(_failed_count), do: 300_000
 
-      defoverridable [timeout: 0, max_retry: 0, retry_interval: 0]
+      defoverridable [timeout: 0, max_retry: 0, retry_interval: 1]
     end
   end
 end

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -22,7 +22,7 @@ defmodule TaskBunny.JobTestHelper do
       end
     end
 
-    def retry_interval, do: RetryInterval.interval()
+    def retry_interval(_), do: RetryInterval.interval()
   end
 
   def wait_for_perform(number \\ 1) do


### PR DESCRIPTION
Change `retry_interval` to take failed_count. It allows you to have coming up with more intelligent retry intervals. For example, retry quickly for the first error and gradually have longer retry interval if it fails again (see README update).