### PR TITLE
`Config.queue_for_job/1` to return Keyword instead of queue name

### DIFF
--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -72,13 +72,11 @@ defmodule TaskBunny.Config do
   @doc """
   Returns queue for the given job
   """
-  @spec queue_for_job(atom) :: String.t
+  @spec queue_for_job(atom) :: keyword
   def queue_for_job(job) do
-    queue = Enum.find(queues(), fn (queue) ->
+    Enum.find(queues(), fn (queue) ->
       match_job?(job, queue[:jobs])
     end) || default_queue()
-
-    if queue, do: queue[:name], else: nil
   end
 
   @spec default_queue :: keyword | nil

--- a/test/task_bunny/config_test.exs
+++ b/test/task_bunny/config_test.exs
@@ -50,12 +50,16 @@ defmodule TaskBunny.ConfigTest do
   end
 
   describe "queue_for_job" do
+    defp queue_for_job(job) do
+      Config.queue_for_job(job)[:name]
+    end
+
     test "returns matched queue" do
-      assert Config.queue_for_job(High.TestJob) == "test.high"
-      assert Config.queue_for_job(SlowJob) == "test.low"
-      assert Config.queue_for_job(SampleJob) == "test.normal"
-      assert Config.queue_for_job(Extra.TestJob) == "extra.queue1"
-      assert Config.queue_for_job(Foo.High.TestJob) == "test.normal"
+      assert queue_for_job(High.TestJob) == "test.high"
+      assert queue_for_job(SlowJob) == "test.low"
+      assert queue_for_job(SampleJob) == "test.normal"
+      assert queue_for_job(Extra.TestJob) == "extra.queue1"
+      assert queue_for_job(Foo.High.TestJob) == "test.normal"
     end
   end
 end


### PR DESCRIPTION
Fix a bug that `Config.queue_for_job/1` returns wrong type. Currently it breaks `Job.enqueue`: https://github.com/shinyscorpion/task_bunny/blob/master/lib/task_bunny/job.ex#L15-L19