### PR TITLE
documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ You want to balance between performance and needs on throttle.
 TaskBunny retries the job if the job has failed.
 By default, it retries 10 times for every 5 minutes.
 
-If you want to change it, you can overwrite the value on a job module.
+If you want to change it, you can override the value on a job module.
 
 ```elixir
 defmodule SampleJob do
@@ -209,7 +209,7 @@ You can also change the retry_interval by the number of failures.
 By default, jobs timeout after 2 minutes.
 If job doesn't respond for more than 2 minutes, worker kills the process and moves it to retry queue.
 
-You can change the timeout by overwriting `timeout/0` in your job.
+You can change the timeout by overriding `timeout/0` in your job.
 
 ```elixir
 defmodule SlowJob do

--- a/lib/mix/tasks/analyze.ex
+++ b/lib/mix/tasks/analyze.ex
@@ -1,7 +1,9 @@
 defmodule Mix.Tasks.Analyze do
-  @moduledoc ~S"""
-  Analyze the code and exit if errors have been found.
-  """
+  # Analyze the code and exit if errors have been found.
+  #
+  # It is a private mix task to TaskBunny.
+  #
+  @moduledoc false
 
   use Mix.Task
 

--- a/lib/mix/tasks/analyze.ex
+++ b/lib/mix/tasks/analyze.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Analyze do
   # Analyze the code and exit if errors have been found.
   #
-  # It is a private mix task to TaskBunny.
+  # It is a private mix task for TaskBunny.
   #
   @moduledoc false
 

--- a/lib/mix/tasks/task_bunny.queue.reset.ex
+++ b/lib/mix/tasks/task_bunny.queue.reset.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.TaskBunny.Queue.Reset do
   Mix task to reset all queues.
 
   It deletes the queues and creates them again.
-  Therefore all messages in the queues will be removed.
+  Therefore all messages in the queues are removed.
   """
 
   alias TaskBunny.{Connection, Config, Queue}

--- a/lib/mix/tasks/task_bunny.queue.reset.ex
+++ b/lib/mix/tasks/task_bunny.queue.reset.ex
@@ -6,8 +6,8 @@ defmodule Mix.Tasks.TaskBunny.Queue.Reset do
   @moduledoc """
   Mix task to reset all queues.
 
-  What it does is that deletes the queues and creates them again.
-  Therefore all messages in the queues will go away.
+  It deletes the queues and creates them again.
+  Therefore all messages in the queues will be removed.
   """
 
   alias TaskBunny.{Connection, Config, Queue}

--- a/lib/mix/tasks/task_bunny.queue.reset.ex
+++ b/lib/mix/tasks/task_bunny.queue.reset.ex
@@ -6,8 +6,8 @@ defmodule Mix.Tasks.TaskBunny.Queue.Reset do
   @moduledoc """
   Mix task to reset all queues.
 
-  Please be aware it delete queues and recreate them.
-  So all existing messages in the queues will go away.
+  What it does is that deletes the queues and creates them again.
+  Therefore all messages in the queues will go away.
   """
 
   alias TaskBunny.{Connection, Config, Queue}

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -66,7 +66,7 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Transforms queue configuration into list of workers application should run.
+  Transforms queue configuration into a list of workers, which the application should run.
   """
   @spec workers :: [keyword]
   def workers do

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -1,13 +1,13 @@
 defmodule TaskBunny.Config do
   @moduledoc """
-  Modules that help you access to TaskBunny config values
+  Handles TaskBunny configuration.
   """
   alias TaskBunny.ConfigError
 
   @default_concurrency 2
 
   @doc """
-  Returns list of hosts in config.
+  Returns list of hosts.
   """
   @spec hosts :: [atom]
   def hosts do
@@ -16,7 +16,13 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Returns host configuration. Returns nil when host is not configured.
+  Returns configuration for the host.
+
+  ## Examples
+
+      iex> host_config(:default)
+      [connection_options: "amqp://localhost?heartbeat=30"]
+
   """
   @spec host_config(atom) :: keyword | nil
   def host_config(host) do
@@ -24,15 +30,16 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Returns connect options for the host. It raises an error if the host is not found.
+  Returns connect options for the host.
   """
   @spec connect_options(host :: atom) :: list | String.t
   def connect_options(host) do
-    hosts_config()[host][:connect_options] || raise "Can not find host '#{host}' in config"
+    hosts_config()[host][:connect_options] ||
+      raise ConfigError, message: "Can not find host '#{host}' in config"
   end
 
   @doc """
-  Returns queues in config.
+  Returns list of queues.
   """
   @spec queues :: [keyword]
   def queues do
@@ -59,7 +66,7 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Returns workers in config.
+  Transforms queue configuration into list of workers application should run.
   """
   @spec workers :: [keyword]
   def workers do
@@ -82,7 +89,7 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Returns queue for the given job
+  Returns a queue for the given job.
   """
   @spec queue_for_job(atom) :: keyword | nil
   def queue_for_job(job) do
@@ -134,7 +141,7 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Returns if auto start is enabled.
+  Returns true if auto start is enabled.
   """
   @spec auto_start? :: boolean
   def auto_start? do
@@ -145,7 +152,7 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Disable auto start manually
+  Disable auto start manually.
   """
   @spec disable_auto_start :: :ok
   def disable_auto_start do

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -66,7 +66,7 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Transforms queue configuration into a list of workers, which the application should run.
+  Transforms queue configuration into list of workers for the application to run.
   """
   @spec workers :: [keyword]
   def workers do

--- a/lib/task_bunny/connection.ex
+++ b/lib/task_bunny/connection.ex
@@ -1,34 +1,36 @@
 defmodule TaskBunny.Connection do
   @moduledoc """
-  TaskBunny.Connection is a GenServer that handles RabbitMQ connection.
-  The module also provides conviniences to access RabbitMQ through the GenServers.
+  A GenServer that handles RabbitMQ connection.
+  It provides convenience functions to access RabbitMQ through the GenServer.
 
   ## GenServer
 
-  TaskBunny loads the configurations and automatically starts GenServers for each host definitions.
-  They are also supervised by TaskBunny so you don't have to look after them at all.
+  TaskBunny loads the configurations and automatically starts a GenServer for each host definition.
+  They are supervised by TaskBunny so you don't have to look after them.
 
   ## Disconnect/Reconnect
 
   TaskBunny handles disconnection and reconnection.
-  Once the GenServer retrieves the RabbitMQ connection, the GenServer monitors it.
-  When it is disconnected(died), the GenServer terminates itself.
+  Once the GenServer retrieves the RabbitMQ connection the GenServer monitors it.
+  When it disconnects or dies the GenServer terminates itself.
 
-  Then the supervisor will restart the GenServer and it tries to connect to the host.
-  If it failes to connect, it retries again and again every five seconds.
+  The supervisor restarts the GenServer and it tries to reconnect to the host.
+  If it fails to connect, it retries every five seconds.
 
   ## Access to RabbitMQ connections
 
-  The module provides two different ways to retrieve RabbitMQ connection.
+  The module provides two ways to retrieve a RabbitMQ connection:
 
-  First way is to use `get_connection/1` and it returns the connection synchronously.
-  Since TaskBunny tries to establish a connection immediately the application starts,
-  this will succeed in most of case.
+  1. Use `get_connection/1` and it returns the connection synchronously.
+  This will succeed in most cases since TaskBunny tries to establish a
+  connection as soon as the application starts.
 
-  Second way is to use `subscribe_connection/1` and it sends back the connection asynchronously once the connection gets ready.
-  This can be useful when you can't ensure the caller might start before the connectin is established.
+  2. Use `subscribe_connection/1` and it sends the connection back
+  asynchronously once the connection is ready.
+  This can be useful when you can't ensure the caller might start before the
+  connectin is established.
 
-  Check out the function document for more details.
+  Check out the function documentation for more details.
   """
 
   use GenServer
@@ -60,7 +62,7 @@ defmodule TaskBunny.Connection do
 
   @doc """
   Returns the RabbitMQ connection for the given host.
-  When host argument was not passed, it returns the connection for the default host.
+  When host argument is not passed it returns the connection for the default host.
 
   ## Examples
 

--- a/lib/task_bunny/connection.ex
+++ b/lib/task_bunny/connection.ex
@@ -37,6 +37,11 @@ defmodule TaskBunny.Connection do
 
   @reconnect_interval 5_000
 
+  @doc """
+  Represents the state of a connection GenServer.
+
+  It's a tuple containing `{host, connection, subscribers}`.
+  """
   @type state :: {atom, %AMQP.Connection{} | nil, list(pid)}
 
   @doc false

--- a/lib/task_bunny/connection.ex
+++ b/lib/task_bunny/connection.ex
@@ -1,9 +1,34 @@
 defmodule TaskBunny.Connection do
   @moduledoc """
-  A GenServer to handle RabbitMQ connection.
-  If it fails to connect to the host, it will retry every 5 seconds.
+  TaskBunny.Connection is a GenServer that handles RabbitMQ connection.
+  The module also provides conviniences to access RabbitMQ through the GenServers.
 
-  The module also provides funcitons to access RabbitMQ connections.
+  ## GenServer
+
+  TaskBunny loads the configurations and automatically starts GenServers for each host definitions.
+  They are also supervised by TaskBunny so you don't have to look after them at all.
+
+  ## Disconnect/Reconnect
+
+  TaskBunny handles disconnection and reconnection.
+  Once the GenServer retrieves the RabbitMQ connection, the GenServer monitors it.
+  When it is disconnected(died), the GenServer terminates itself.
+
+  Then the supervisor will restart the GenServer and it tries to connect to the host.
+  If it failes to connect, it retries again and again every five seconds.
+
+  ## Get RabbitMQ connections
+
+  The module provides two different ways to retrieve RabbitMQ connection.
+
+  First way is to use `get_connection/1` and it returns the connection synchronously.
+  Since TaskBunny tries to establish a connection immediately the application starts,
+  this will succeed in most of case.
+
+  Second way is to use `subscribe_connection/1` and it sends back the connection asynchronously once the connection gets ready.
+  This can be useful when you can't ensure the caller might start before the connectin is established.
+
+  Check out the function document for more details.
   """
 
   use GenServer
@@ -14,9 +39,7 @@ defmodule TaskBunny.Connection do
 
   @type state :: {atom, %AMQP.Connection{} | nil, list(pid)}
 
-  @doc """
-  Starts a GenServer process linked to the cunnrent process.
-  """
+  @doc false
   @spec start_link(atom | state) :: GenServer.on_start
   def start_link(host)
 
@@ -31,10 +54,16 @@ defmodule TaskBunny.Connection do
   end
 
   @doc """
-  Gets a RabbitMQ connection for the given host.
+  Returns the RabbitMQ connection for the given host.
+  When host argument was not passed, it returns the connection for the default host.
 
-  Returns {:ok, conn} when connection is available.
-  Returns {:error, error_info} when connection is not ready.
+  ## Examples
+
+      case get_connection() do
+        {:ok, conn} -> do_something(conn)
+        {:error, _} -> cry()
+      end
+
   """
   @spec get_connection(atom) :: {:ok, AMQP.Connection.t} | {:error, atom}
   def get_connection(host \\ :default) do
@@ -55,7 +84,11 @@ defmodule TaskBunny.Connection do
   @doc """
   Similar to get_connection/1 but raises an exception when connection is not ready.
 
-  Returns connection if it's available.
+  ## Examples
+
+      iex> conn = get_connection!()
+      %AMQP.Connection{}
+
   """
   @spec get_connection!(atom) :: AMQP.Connection.t
   def get_connection!(host \\ :default) do
@@ -66,11 +99,16 @@ defmodule TaskBunny.Connection do
   end
 
   @doc """
-  Asks server to send the connection back asynchronously.
+  Requests the GenServer to send the connection back asynchronously.
   Once connection has been established, it will send a message with {:connected, connection} to the given process.
 
-  Returns :ok when the server exists.
-  Returns {:error, info} when the server doesn't exist.
+  ## Examples
+
+      :ok = subscribe_connection(self())
+      receive do
+        {:connected, conn = %AMQP.Connection{}} -> do_something(conn)
+      end
+
   """
   @spec subscribe_connection(atom, pid) :: :ok | {:error, atom}
   def subscribe_connection(host \\ :default, listener_pid) do
@@ -88,6 +126,13 @@ defmodule TaskBunny.Connection do
 
   @doc """
   Similar to subscribe_connection/2 but raises an exception when process is not ready.
+  ## Examples
+
+      subscribe_connection!(self())
+      receive do
+        {:connected, conn = %AMQP.Connection{}} -> do_something(conn)
+      end
+
   """
   @spec subscribe_connection!(atom, pid) :: :ok
   def subscribe_connection!(host \\ :default, listener_pid) do

--- a/lib/task_bunny/connection.ex
+++ b/lib/task_bunny/connection.ex
@@ -17,7 +17,7 @@ defmodule TaskBunny.Connection do
   Then the supervisor will restart the GenServer and it tries to connect to the host.
   If it failes to connect, it retries again and again every five seconds.
 
-  ## Get RabbitMQ connections
+  ## Access to RabbitMQ connections
 
   The module provides two different ways to retrieve RabbitMQ connection.
 

--- a/lib/task_bunny/consumer.ex
+++ b/lib/task_bunny/consumer.ex
@@ -1,11 +1,13 @@
 defmodule TaskBunny.Consumer do
-  @moduledoc """
-  Functions that work on RabbitMQ consumer
-  """
+  # Handles consumer concerns.
+  #
+  # This module is private to TaskBunny and should not be accessed directly.
+  #
+  @moduledoc false
   require Logger
 
   @doc """
-  Opens a channel for the given connection and start consuming messages for the queue.
+  Opens a channel and start consuming messages for the queue.
   """
   @spec consume(AMQP.Connection.t, String.t, integer) :: {:ok, AMQP.Channel.t, String.t} | {:error, any}
   def consume(connection, queue, concurrency) do
@@ -26,7 +28,7 @@ defmodule TaskBunny.Consumer do
   end
 
   @doc """
-  Cancel consumer to stop receiving messages.
+  Cancel the consumer to stop receiving messages.
   """
   @spec cancel(AMQP.Channel.t, String.t) :: {:ok, String.t}
   def cancel(channel, consumer_tag) do

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -30,11 +30,11 @@ defmodule TaskBunny.Job do
 
   ## Timeout
 
-  In default, TaskBunny terminates the job when it takes more than 2 minutes.
-  This helps you to avoid messages stuck in your queue.
+  By default TaskBunny terminates the job when it takes more than 2 minutes.
+  Having right timeout avoids jobs to block a worker.
 
   If your job is expected to take longer than 2 minutes or you want to terminate
-  the job earlier, overwrite `timeout/0` function.
+  the job earlier, overwrite the `timeout/0` function.
 
       defmodule SlowJob do
         use TaskBunny.Job
@@ -49,11 +49,11 @@ defmodule TaskBunny.Job do
 
   # Retry
 
-  In default, TaskBunny retries 10 times every five minutes for a failed job.
+  By default TaskBunny retries 10 times every five minutes for a failed job.
   You can change the behavior by overwriting `max_retry/0` and `retry_interval/1`.
 
   For example, if you want the job to be retried five times and gradually
-  increase the inteval based on failed times, you can write the logic like
+  increase the interval based on failed times, you can write the logic like
   the following.
 
       defmodule HttpSyncJob do
@@ -142,7 +142,7 @@ defmodule TaskBunny.Job do
       @spec timeout() :: integer
       def timeout, do: 120_000
 
-      # Retries 10 times in every 5 minutes in default.
+      # Retries 10 times in every 5 minutes by default.
       # You have to re-create the queue after you change retry_interval.
       @doc false
       @spec max_retry() :: integer
@@ -167,8 +167,8 @@ defmodule TaskBunny.Job do
 
   ## Options
 
-  - host: RabbitMQ host. In default, it's automatically selected from configuration.
-  - queue: RabbitMQ queue. In default, It's automattically selected from configuration.
+  - host: RabbitMQ host. By default it is automatically selected from configuration.
+  - queue: RabbitMQ queue. By default It is automattically selected from configuration.
 
   """
   @spec enqueue(atom, any, keyword) :: :ok | {:error, any}

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -70,7 +70,49 @@ defmodule TaskBunny.Job do
 
   """
 
+  @doc """
+  Callback to process a job.
+
+  It can take any type of argument as long as it can be seriarlized with Poison
+  but we recommend you to use map with string keys for a consistency.
+
+      def perform(name) do
+        IO.puts name <> ", it's not a preferred way"
+      end
+
+      def perform(%{"name" => name}) do
+        IO.puts name <> ", it's a preferred way :)"
+      end
+
+  """
   @callback perform(any) :: :ok | {:error, term}
+
+  @doc """
+  Callback for the timeout in milliseconds for a job execution.
+
+  Default value is 120_000 = 2 minutes.
+  Overwrite the function if you want to change the value.
+  """
+  @callback timeout() :: integer
+
+  @doc """
+  Callback for the max number of retries TaskBunny can make for a failed job.
+
+  Default value is 10.
+  Overwrite the function if you want to change the value.
+  """
+  @callback max_retry() :: integer
+
+  @doc """
+  Callback for the retry interval in milliseconds.
+
+  Default value is 300_000 = 5 minutes.
+  Overwrite the function if you want to change the value.
+
+  TaskBunny will set failed count to the argument.
+  The value will be more than or equal to 1 and less than or equal to max_retry.
+  """
+  @callback retry_interval(integer) :: integer
 
   require Logger
   alias TaskBunny.{Config, Queue, Job, Message, Publisher}

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -31,10 +31,10 @@ defmodule TaskBunny.Job do
   ## Timeout
 
   By default TaskBunny terminates the job when it takes more than 2 minutes.
-  Having right timeout avoids jobs to block a worker.
+  This prevents messages blocking a worker.
 
   If your job is expected to take longer than 2 minutes or you want to terminate
-  the job earlier, overwrite the `timeout/0` function.
+  the job earlier, override `timeout/0`.
 
       defmodule SlowJob do
         use TaskBunny.Job
@@ -50,11 +50,11 @@ defmodule TaskBunny.Job do
   # Retry
 
   By default TaskBunny retries 10 times every five minutes for a failed job.
-  You can change the behavior by overwriting `max_retry/0` and `retry_interval/1`.
+  You can change this by overriding `max_retry/0` and `retry_interval/1`.
 
   For example, if you want the job to be retried five times and gradually
-  increase the interval based on failed times, you can write the logic like
-  the following.
+  increase the interval based on failed times, you can write logic like
+  the following:
 
       defmodule HttpSyncJob do
         def max_retry, do: 5
@@ -73,7 +73,7 @@ defmodule TaskBunny.Job do
   @doc """
   Callback to process a job.
 
-  It can take any type of argument as long as it can be seriarlized with Poison
+  It can take any type of argument as long as it can be serialized with Poison,
   but we recommend you to use map with string keys for a consistency.
 
       def perform(name) do
@@ -91,7 +91,7 @@ defmodule TaskBunny.Job do
   Callback for the timeout in milliseconds for a job execution.
 
   Default value is 120_000 = 2 minutes.
-  Overwrite the function if you want to change the value.
+  Override the function if you want to change the value.
   """
   @callback timeout() :: integer
 
@@ -99,7 +99,7 @@ defmodule TaskBunny.Job do
   Callback for the max number of retries TaskBunny can make for a failed job.
 
   Default value is 10.
-  Overwrite the function if you want to change the value.
+  Override the function if you want to change the value.
   """
   @callback max_retry() :: integer
 
@@ -107,7 +107,7 @@ defmodule TaskBunny.Job do
   Callback for the retry interval in milliseconds.
 
   Default value is 300_000 = 5 minutes.
-  Overwrite the function if you want to change the value.
+  Override the function if you want to change the value.
 
   TaskBunny will set failed count to the argument.
   The value will be more than or equal to 1 and less than or equal to max_retry.
@@ -137,7 +137,7 @@ defmodule TaskBunny.Job do
       end
 
       # Returns timeout (default 2 minutes).
-      # Overwrite the method to change the timeout.
+      # Override the method to change the timeout.
       @doc false
       @spec timeout() :: integer
       def timeout, do: 120_000
@@ -168,7 +168,7 @@ defmodule TaskBunny.Job do
   ## Options
 
   - host: RabbitMQ host. By default it is automatically selected from configuration.
-  - queue: RabbitMQ queue. By default It is automattically selected from configuration.
+  - queue: RabbitMQ queue. By default it is automatically selected from configuration.
 
   """
   @spec enqueue(atom, any, keyword) :: :ok | {:error, any}

--- a/lib/task_bunny/job_runner.ex
+++ b/lib/task_bunny/job_runner.ex
@@ -1,21 +1,25 @@
 defmodule TaskBunny.JobRunner do
-  @moduledoc """
-  JobRunner wraps up job execution and provides you abilities:
-
-  - invoking jobs concurrently (unblocking job execution)
-  - handling a job crashing
-  - handling timeout
-
-  ## Signal
-
-  Once the job has finished it sends a message with a tuple consisted with:
-
-  - atom indicating message type: :job_finished
-  - result: :ok or {:error, details}
-  - meta: meta data for the job
-
-  After sending the messsage, JobRunner shuts down all processes it started.
-  """
+  # Handles job invocation concerns.
+  #
+  # This module is private to TaskBunny and should not be accessed directly.
+  #
+  # JobRunner wraps up job execution and provides you abilities:
+  #
+  # - invoking jobs concurrently (unblocking job execution)
+  # - handling a job crashing
+  # - handling timeout
+  #
+  # ## Signal
+  #
+  # Once the job has finished it sends a message with a tuple consisted with:
+  #
+  # - atom indicating message type: :job_finished
+  # - result: :ok or {:error, details}
+  # - meta: meta data for the job
+  #
+  # After sending the messsage, JobRunner shuts down all processes it started.
+  #
+  @moduledoc false
 
   require Logger
 
@@ -51,11 +55,11 @@ defmodule TaskBunny.JobRunner do
     job.perform(payload)
   rescue
     error ->
-      Logger.error "TaskBunny.Worker - Runner rescued #{inspect error}"
+      Logger.error "TaskBunny.JobRunner - Runner rescued #{inspect error}"
       {:error, error}
   catch
     _, reason ->
-      Logger.error "TaskBunny.Worker - Runner caught reason: #{inspect reason}"
+      Logger.error "TaskBunny.JobRunner - Runner caught reason: #{inspect reason}"
       {:error, reason}
   end
 end

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -2,7 +2,7 @@ defmodule TaskBunny.Message do
   @moduledoc """
   Functions that work on TaskBunny messages.
 
-  It's a semi private module and it is used by Job or Worker module.
+  It is a semi private module and it is used by Job or Worker module.
   You wouldn't have to deal with it normally.
 
   However in case you need to encode/decode TaskBunny messages,

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -2,8 +2,8 @@ defmodule TaskBunny.Message do
   @moduledoc """
   Functions that work on TaskBunny messages.
 
-  It is a semi private module and it is used by Job or Worker module.
-  You wouldn't have to deal with it normally.
+  It's a semi private module used by Job or Worker.
+  You shouldn't have to deal with it normally.
 
   However in case you need to encode/decode TaskBunny messages,
   this module will help.
@@ -11,7 +11,7 @@ defmodule TaskBunny.Message do
   alias TaskBunny.Message.DecodeError
 
   @doc """
-  Encode message body in JSON with job and arugment.
+  Encode message body in JSON with job and argument.
   """
   @spec encode(atom, any) :: {:ok, String.t}
   def encode(job, payload) do
@@ -121,7 +121,7 @@ defmodule TaskBunny.Message do
   end
 
   @doc """
-  Returns a number of errors occurred for the message
+  Returns a number of errors occurred for the message.
   """
   @spec failed_count(String.t|map) :: integer
   def failed_count(message) when is_map(message) do

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -1,6 +1,12 @@
 defmodule TaskBunny.Message do
   @moduledoc """
-  Functions to access messages and its meta data.
+  Functions that work on TaskBunny messages.
+
+  It's a semi private module and it is used by Job or Worker module.
+  You wouldn't have to deal with it normally.
+
+  However in case you need to encode/decode TaskBunny messages,
+  this module will help.
   """
   alias TaskBunny.Message.DecodeError
 
@@ -14,7 +20,7 @@ defmodule TaskBunny.Message do
   end
 
   @doc """
-  Similar to encode/2 but raises an exception on error
+  Similar to encode/2 but raises an exception on error.
   """
   @spec encode!(atom, any) :: String.t
   def encode!(job, payload) do
@@ -32,7 +38,7 @@ defmodule TaskBunny.Message do
   end
 
   @doc """
-  Decode message body in JSON to map
+  Decode message body in JSON to map data.
   """
   @spec decode(String.t) :: {:ok, map} | {:error, any}
   def decode(message) do

--- a/lib/task_bunny/publisher.ex
+++ b/lib/task_bunny/publisher.ex
@@ -2,7 +2,7 @@ defmodule TaskBunny.Publisher do
   @moduledoc """
   Conviniences for publishing messages to a queue.
 
-  It provides lower level functions.
+  It's a semi private module and provides lower level functions.
   You should use Job.enqueue to enqueue a job from your application.
   """
   require Logger

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -1,8 +1,8 @@
 defmodule TaskBunny.Queue do
   @moduledoc """
-  Conviniences for accessing TaskBunny queues.
+  Convenience functions for accessing TaskBunny queues.
 
-  It's a semi private module and it is normally wrapped by other modules.
+  It's a semi private module normally wrapped by other modules.
 
   ## Sub Queues
 
@@ -100,7 +100,7 @@ defmodule TaskBunny.Queue do
   end
 
   @doc """
-  Returns a list that contains the queue and its subqueue
+  Returns a list that contains the queue and its subqueue.
   """
   @spec queue_with_subqueues(String.t) :: [String.t]
   def queue_with_subqueues(work_queue) do
@@ -108,7 +108,7 @@ defmodule TaskBunny.Queue do
   end
 
   @doc """
-  Returns all sub queues for the work queue.
+  Returns all subqueues for the work queue.
   """
   @spec subqueues(String.t) :: [String.t]
   def subqueues(work_queue) do

--- a/lib/task_bunny/status.ex
+++ b/lib/task_bunny/status.ex
@@ -1,9 +1,9 @@
 defmodule TaskBunny.Status do
   @moduledoc false
-  # Functions that handles TaskBunny status.
+  # Functions that handle TaskBunny status.
   #
   # This module is private to TaskBunny.
-  # It's aimed to provide useful stats to Wobserver integration.
+  # It's aimed at providing useful stats to Wobserver integration.
   #
   alias TaskBunny.{Status, Connection}
   alias TaskBunny.Status.Worker
@@ -13,7 +13,7 @@ defmodule TaskBunny.Status do
     - `version`, the current status version.
     - `up`, whether the `TaskBunny.Supervisor` is running.
     - `connected`, whether a connection to RabbitMQ has been made.
-    - `workers`, list of worker statusses.
+    - `workers`, list of worker statuses.
   """
   @type t :: %__MODULE__{version: String.t, up: boolean, connected: boolean, workers: list(Worker.t)}
 

--- a/lib/task_bunny/status.ex
+++ b/lib/task_bunny/status.ex
@@ -1,8 +1,10 @@
 defmodule TaskBunny.Status do
-  @moduledoc ~S"""
-  Modules that handles TaskBunny status.
-  """
-
+  @moduledoc false
+  # Functions that handles TaskBunny status.
+  #
+  # This module is private to TaskBunny.
+  # It's aimed to provide useful stats to Wobserver integration.
+  #
   alias TaskBunny.{Status, Connection}
   alias TaskBunny.Status.Worker
 

--- a/lib/task_bunny/status/worker.ex
+++ b/lib/task_bunny/status/worker.ex
@@ -1,7 +1,10 @@
 defmodule TaskBunny.Status.Worker do
-  @moduledoc ~S"""
-  Modules that handles the Worker status.
-  """
+  @moduledoc false
+  # Functions that handles the Worker status.
+  #
+  # This module is private to TaskBunny.
+  # It's aimed to provide useful stats to Wobserver integration.
+  #
 
   @typedoc ~S"""
   The Worker status contains the follow fields:

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -6,17 +6,20 @@ defmodule TaskBunny.Supervisor do
   When Connection crashes, it will restart all Worker through WorkerSupervisor
   so workers can always use re-established connection.
 
-  It loads RabbitMQ hosts and workers from config.
+  You don't have to call or start Supervisor explicity.
+  It will be automatically started by application and
+  configure child processes based on configuration file.
   """
-
   use Supervisor
   alias TaskBunny.{Connection, Config, WorkerSupervisor}
 
+  @doc false
   @spec start_link(atom, atom) :: {:ok, pid} | {:error, term}
   def start_link(name \\ __MODULE__, wsv_name \\ WorkerSupervisor) do
     Supervisor.start_link(__MODULE__, [wsv_name], name: name)
   end
 
+  @doc false
   @spec init(list()) ::
     {:ok, {:supervisor.sup_flags, [Supervisor.Spec.spec]}} |
     :ignore

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -3,8 +3,8 @@ defmodule TaskBunny.Supervisor do
   Main supervisor for TaskBunny.
 
   It supervises Connection and WorkerSupervisor with one_for_all strategy.
-  When Connection crashes, it will restart all Worker through WorkerSupervisor
-  so workers can always use re-established connection.
+  When Connection crashes it restarts all Worker processes through WorkerSupervisor
+  so workers can always use a re-established connection.
 
   You don't have to call or start the Supervisor explicity.
   It will be automatically started by application and

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -6,7 +6,7 @@ defmodule TaskBunny.Supervisor do
   When Connection crashes, it will restart all Worker through WorkerSupervisor
   so workers can always use re-established connection.
 
-  You don't have to call or start Supervisor explicity.
+  You don't have to call or start the Supervisor explicity.
   It will be automatically started by application and
   configure child processes based on configuration file.
   """

--- a/lib/task_bunny/worker_supervisor.ex
+++ b/lib/task_bunny/worker_supervisor.ex
@@ -1,22 +1,24 @@
 defmodule TaskBunny.WorkerSupervisor do
   @moduledoc """
-  Worker supervisor for TaskBunny.
+  Supervises all TaskBunny workers.
 
-  It supervises all Workers with one_for_one strategy.
+  You don't have to call or start Supervisor explicity.
+  It will be automatically started by application and
+  configure child workers based on configuration file.
 
-  It will receive all jobs that need workers when started and will start a worker for each job.
+  It also provides `graceful_halt/1` and `graceful_halt/2` that allow
+  you to shutdown the worker processes safely.
   """
-
   use Supervisor
   alias TaskBunny.{Config, Worker}
 
-  @type jobs :: list({host :: atom, job :: atom, concurrenct :: integer})
-
+  @doc false
   @spec start_link(atom) :: {:ok, pid} | {:error, term}
   def start_link(name \\ __MODULE__) do
     Supervisor.start_link(__MODULE__, [], name: name)
   end
 
+  @doc false
   @spec init(list) :: {:ok, {:supervisor.sup_flags, [Supervisor.Spec.spec]}} | :ignore
   def init([]) do
     Config.workers()

--- a/lib/task_bunny/worker_supervisor.ex
+++ b/lib/task_bunny/worker_supervisor.ex
@@ -2,7 +2,7 @@ defmodule TaskBunny.WorkerSupervisor do
   @moduledoc """
   Supervises all TaskBunny workers.
 
-  You don't have to call or start Supervisor explicity.
+  You don't have to call or start the Supervisor explicity.
   It will be automatically started by application and
   configure child workers based on configuration file.
 

--- a/lib/task_bunny/worker_supervisor.ex
+++ b/lib/task_bunny/worker_supervisor.ex
@@ -36,9 +36,9 @@ defmodule TaskBunny.WorkerSupervisor do
   Halts the job pocessing on workers gracefully.
   It makes workers to stop processing new jobs and waits for jobs currently running to finish.
 
-  Note it doesn't terminate any worker processes.
+  Note: It doesn't terminate any worker processes.
   The worker and worker supervisor processes will continue existing but won't consume any new messages.
-  To resume it, terminate the worker supervisor then main supervisor will start new processes.
+  To resume it, terminate the worker supervisor then the main supervisor will start new processes.
   """
   @spec graceful_halt(pid|nil, integer) :: :ok | {:error, any}
 


### PR DESCRIPTION
Overhauled `@moduledoc`, `@doc` and `@typedoc`. Hopefully it makes more sense.