### PR TITLE
Docs/moduledoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ You want to balance between performance and needs on throttle.
 TaskBunny retries the job if the job has failed.
 By default, it retries 10 times for every 5 minutes.
 
-If you want to change it, you can overwrite the value on a job module.
+If you want to change it, you can override the value on a job module.
 
 ```elixir
 defmodule SampleJob do
@@ -209,7 +209,7 @@ You can also change the retry_interval by the number of failures.
 By default, jobs timeout after 2 minutes.
 If job doesn't respond for more than 2 minutes, worker kills the process and moves it to retry queue.
 
-You can change the timeout by overwriting `timeout/0` in your job.
+You can change the timeout by overriding `timeout/0` in your job.
 
 ```elixir
 defmodule SlowJob do

--- a/lib/mix/tasks/analyze.ex
+++ b/lib/mix/tasks/analyze.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Analyze do
   # Analyze the code and exit if errors have been found.
   #
-  # It is a private mix task to TaskBunny.
+  # It is a private mix task for TaskBunny.
   #
   @moduledoc false
 

--- a/lib/mix/tasks/task_bunny.queue.reset.ex
+++ b/lib/mix/tasks/task_bunny.queue.reset.ex
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.TaskBunny.Queue.Reset do
   Mix task to reset all queues.
 
   It deletes the queues and creates them again.
-  Therefore all messages in the queues will be removed.
+  Therefore all messages in the queues are removed.
   """
 
   alias TaskBunny.{Connection, Config, Queue}

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -66,7 +66,7 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
-  Transforms queue configuration into a list of workers, which the application should run.
+  Transforms queue configuration into list of workers for the application to run.
   """
   @spec workers :: [keyword]
   def workers do

--- a/lib/task_bunny/connection.ex
+++ b/lib/task_bunny/connection.ex
@@ -1,34 +1,36 @@
 defmodule TaskBunny.Connection do
   @moduledoc """
-  TaskBunny.Connection is a GenServer that handles RabbitMQ connection.
-  The module also provides conviniences to access RabbitMQ through the GenServers.
+  A GenServer that handles RabbitMQ connection.
+  It provides convenience functions to access RabbitMQ through the GenServer.
 
   ## GenServer
 
-  TaskBunny loads the configurations and automatically starts GenServers for each host definitions.
-  They are also supervised by TaskBunny so you don't have to look after them at all.
+  TaskBunny loads the configurations and automatically starts a GenServer for each host definition.
+  They are supervised by TaskBunny so you don't have to look after them.
 
   ## Disconnect/Reconnect
 
   TaskBunny handles disconnection and reconnection.
-  Once the GenServer retrieves the RabbitMQ connection, the GenServer monitors it.
-  When it is disconnected(died), the GenServer terminates itself.
+  Once the GenServer retrieves the RabbitMQ connection the GenServer monitors it.
+  When it disconnects or dies the GenServer terminates itself.
 
-  Then the supervisor will restart the GenServer and it tries to connect to the host.
-  If it failes to connect, it retries again and again every five seconds.
+  The supervisor restarts the GenServer and it tries to reconnect to the host.
+  If it fails to connect, it retries every five seconds.
 
   ## Access to RabbitMQ connections
 
-  The module provides two different ways to retrieve RabbitMQ connection.
+  The module provides two ways to retrieve a RabbitMQ connection:
 
-  First way is to use `get_connection/1` and it returns the connection synchronously.
-  Since TaskBunny tries to establish a connection immediately the application starts,
-  this will succeed in most of case.
+  1. Use `get_connection/1` and it returns the connection synchronously.
+  This will succeed in most cases since TaskBunny tries to establish a
+  connection as soon as the application starts.
 
-  Second way is to use `subscribe_connection/1` and it sends back the connection asynchronously once the connection gets ready.
-  This can be useful when you can't ensure the caller might start before the connectin is established.
+  2. Use `subscribe_connection/1` and it sends the connection back
+  asynchronously once the connection is ready.
+  This can be useful when you can't ensure the caller might start before the
+  connectin is established.
 
-  Check out the function document for more details.
+  Check out the function documentation for more details.
   """
 
   use GenServer
@@ -60,7 +62,7 @@ defmodule TaskBunny.Connection do
 
   @doc """
   Returns the RabbitMQ connection for the given host.
-  When host argument was not passed, it returns the connection for the default host.
+  When host argument is not passed it returns the connection for the default host.
 
   ## Examples
 

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -34,7 +34,7 @@ defmodule TaskBunny.Job do
   This prevents messages blocking a worker.
 
   If your job is expected to take longer than 2 minutes or you want to terminate
-  the job earlier, overwrite `timeout/0`.
+  the job earlier, override `timeout/0`.
 
       defmodule SlowJob do
         use TaskBunny.Job
@@ -50,7 +50,7 @@ defmodule TaskBunny.Job do
   # Retry
 
   By default TaskBunny retries 10 times every five minutes for a failed job.
-  You can change this by overwriting `max_retry/0` and `retry_interval/1`.
+  You can change this by overriding `max_retry/0` and `retry_interval/1`.
 
   For example, if you want the job to be retried five times and gradually
   increase the interval based on failed times, you can write logic like
@@ -91,7 +91,7 @@ defmodule TaskBunny.Job do
   Callback for the timeout in milliseconds for a job execution.
 
   Default value is 120_000 = 2 minutes.
-  Overwrite the function if you want to change the value.
+  Override the function if you want to change the value.
   """
   @callback timeout() :: integer
 
@@ -99,7 +99,7 @@ defmodule TaskBunny.Job do
   Callback for the max number of retries TaskBunny can make for a failed job.
 
   Default value is 10.
-  Overwrite the function if you want to change the value.
+  Override the function if you want to change the value.
   """
   @callback max_retry() :: integer
 
@@ -107,7 +107,7 @@ defmodule TaskBunny.Job do
   Callback for the retry interval in milliseconds.
 
   Default value is 300_000 = 5 minutes.
-  Overwrite the function if you want to change the value.
+  Override the function if you want to change the value.
 
   TaskBunny will set failed count to the argument.
   The value will be more than or equal to 1 and less than or equal to max_retry.
@@ -137,7 +137,7 @@ defmodule TaskBunny.Job do
       end
 
       # Returns timeout (default 2 minutes).
-      # Overwrite the method to change the timeout.
+      # Override the method to change the timeout.
       @doc false
       @spec timeout() :: integer
       def timeout, do: 120_000

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -31,10 +31,10 @@ defmodule TaskBunny.Job do
   ## Timeout
 
   By default TaskBunny terminates the job when it takes more than 2 minutes.
-  Having right timeout avoids jobs to block a worker.
+  This prevents messages blocking a worker.
 
   If your job is expected to take longer than 2 minutes or you want to terminate
-  the job earlier, overwrite the `timeout/0` function.
+  the job earlier, overwrite `timeout/0`.
 
       defmodule SlowJob do
         use TaskBunny.Job
@@ -50,11 +50,11 @@ defmodule TaskBunny.Job do
   # Retry
 
   By default TaskBunny retries 10 times every five minutes for a failed job.
-  You can change the behavior by overwriting `max_retry/0` and `retry_interval/1`.
+  You can change this by overwriting `max_retry/0` and `retry_interval/1`.
 
   For example, if you want the job to be retried five times and gradually
-  increase the interval based on failed times, you can write the logic like
-  the following.
+  increase the interval based on failed times, you can write logic like
+  the following:
 
       defmodule HttpSyncJob do
         def max_retry, do: 5
@@ -73,7 +73,7 @@ defmodule TaskBunny.Job do
   @doc """
   Callback to process a job.
 
-  It can take any type of argument as long as it can be seriarlized with Poison
+  It can take any type of argument as long as it can be serialized with Poison,
   but we recommend you to use map with string keys for a consistency.
 
       def perform(name) do
@@ -168,7 +168,7 @@ defmodule TaskBunny.Job do
   ## Options
 
   - host: RabbitMQ host. By default it is automatically selected from configuration.
-  - queue: RabbitMQ queue. By default It is automattically selected from configuration.
+  - queue: RabbitMQ queue. By default it is automatically selected from configuration.
 
   """
   @spec enqueue(atom, any, keyword) :: :ok | {:error, any}

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -2,8 +2,8 @@ defmodule TaskBunny.Message do
   @moduledoc """
   Functions that work on TaskBunny messages.
 
-  It is a semi private module and it is used by Job or Worker module.
-  You wouldn't have to deal with it normally.
+  It's a semi private module used by Job or Worker.
+  You shouldn't have to deal with it normally.
 
   However in case you need to encode/decode TaskBunny messages,
   this module will help.
@@ -11,7 +11,7 @@ defmodule TaskBunny.Message do
   alias TaskBunny.Message.DecodeError
 
   @doc """
-  Encode message body in JSON with job and arugment.
+  Encode message body in JSON with job and argument.
   """
   @spec encode(atom, any) :: {:ok, String.t}
   def encode(job, payload) do
@@ -121,7 +121,7 @@ defmodule TaskBunny.Message do
   end
 
   @doc """
-  Returns a number of errors occurred for the message
+  Returns a number of errors occurred for the message.
   """
   @spec failed_count(String.t|map) :: integer
   def failed_count(message) when is_map(message) do

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -1,8 +1,8 @@
 defmodule TaskBunny.Queue do
   @moduledoc """
-  Conviniences for accessing TaskBunny queues.
+  Convenience functions for accessing TaskBunny queues.
 
-  It's a semi private module and it is normally wrapped by other modules.
+  It's a semi private module normally wrapped by other modules.
 
   ## Sub Queues
 
@@ -100,7 +100,7 @@ defmodule TaskBunny.Queue do
   end
 
   @doc """
-  Returns a list that contains the queue and its subqueue
+  Returns a list that contains the queue and its subqueue.
   """
   @spec queue_with_subqueues(String.t) :: [String.t]
   def queue_with_subqueues(work_queue) do
@@ -108,7 +108,7 @@ defmodule TaskBunny.Queue do
   end
 
   @doc """
-  Returns all sub queues for the work queue.
+  Returns all subqueues for the work queue.
   """
   @spec subqueues(String.t) :: [String.t]
   def subqueues(work_queue) do

--- a/lib/task_bunny/status.ex
+++ b/lib/task_bunny/status.ex
@@ -1,9 +1,9 @@
 defmodule TaskBunny.Status do
   @moduledoc false
-  # Functions that handles TaskBunny status.
+  # Functions that handle TaskBunny status.
   #
   # This module is private to TaskBunny.
-  # It's aimed to provide useful stats to Wobserver integration.
+  # It's aimed at providing useful stats to Wobserver integration.
   #
   alias TaskBunny.{Status, Connection}
   alias TaskBunny.Status.Worker
@@ -13,7 +13,7 @@ defmodule TaskBunny.Status do
     - `version`, the current status version.
     - `up`, whether the `TaskBunny.Supervisor` is running.
     - `connected`, whether a connection to RabbitMQ has been made.
-    - `workers`, list of worker statusses.
+    - `workers`, list of worker statuses.
   """
   @type t :: %__MODULE__{version: String.t, up: boolean, connected: boolean, workers: list(Worker.t)}
 

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -3,8 +3,8 @@ defmodule TaskBunny.Supervisor do
   Main supervisor for TaskBunny.
 
   It supervises Connection and WorkerSupervisor with one_for_all strategy.
-  When Connection crashes, it will restart all Worker through WorkerSupervisor
-  so workers can always use re-established connection.
+  When Connection crashes it restarts all Worker processes through WorkerSupervisor
+  so workers can always use a re-established connection.
 
   You don't have to call or start the Supervisor explicity.
   It will be automatically started by application and

--- a/lib/task_bunny/worker_supervisor.ex
+++ b/lib/task_bunny/worker_supervisor.ex
@@ -36,9 +36,9 @@ defmodule TaskBunny.WorkerSupervisor do
   Halts the job pocessing on workers gracefully.
   It makes workers to stop processing new jobs and waits for jobs currently running to finish.
 
-  Note it doesn't terminate any worker processes.
+  Note: It doesn't terminate any worker processes.
   The worker and worker supervisor processes will continue existing but won't consume any new messages.
-  To resume it, terminate the worker supervisor then main supervisor will start new processes.
+  To resume it, terminate the worker supervisor then the main supervisor will start new processes.
   """
   @spec graceful_halt(pid|nil, integer) :: :ok | {:error, any}
 


### PR DESCRIPTION
* Fix typos
* Change wording of sentences
* Replace wording overwrite to override. Subtle difference but the macro is called defoverridable so I think that is what is meant.