### PR TITLE
Disable worker with environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ When you use TaskBunny under an umbrella app and each apps needs a different que
   ]
 ```
 
+### Disable worker
+
+When you don't want to run TaskBunny workers in an environment set `1`, `TRUE` or `YES` to `TASK_BUNNY_DISABLE_WORKER` environment variable.
+
 ### Wobserver Integration
 
 TaskBunny automatically integrates with [Wobserver](https://github.com/shinyscorpion/wobserver).

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -152,6 +152,17 @@ defmodule TaskBunny.Config do
   end
 
   @doc """
+  Returns true if worker is disabled.
+  """
+  @spec disable_worker? :: boolean
+  def disable_worker? do
+    ["1", "true", "yes"]
+    |> Enum.any?(fn (truthy) ->
+      truthy == String.downcase(System.get_env("TASK_BUNNY_DISABLE_WORKER"))
+    end)
+  end
+
+  @doc """
   Disable auto start manually.
   """
   @spec disable_auto_start :: :ok

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -156,11 +156,11 @@ defmodule TaskBunny.Config do
   """
   @spec disable_worker? :: boolean
   def disable_worker? do
-    env = System.get_env("TASK_BUNNY_DISABLE_WORKER") || ""
-    ["1", "true", "yes"]
-    |> Enum.any?(fn (truthy) ->
-      truthy == String.downcase(env)
-    end)
+    env =
+      (System.get_env("TASK_BUNNY_DISABLE_WORKER") || "false")
+      |> String.downcase
+
+    ["1", "true", "yes"] |> Enum.member?(env)
   end
 
   @doc """

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -156,9 +156,10 @@ defmodule TaskBunny.Config do
   """
   @spec disable_worker? :: boolean
   def disable_worker? do
+    env = System.get_env("TASK_BUNNY_DISABLE_WORKER") || ""
     ["1", "true", "yes"]
     |> Enum.any?(fn (truthy) ->
-      truthy == String.downcase(System.get_env("TASK_BUNNY_DISABLE_WORKER"))
+      truthy == String.downcase(env)
     end)
   end
 

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -31,10 +31,13 @@ defmodule TaskBunny.Supervisor do
 
     # Define workers and child supervisors to be supervised
     children =
-      case Config.auto_start?() do
-        true ->
+      case {Config.auto_start?, Config.disable_worker?} do
+        {true, false} ->
           connections ++ [supervisor(WorkerSupervisor, [wsv_name])]
-        false ->
+        {true, true} ->
+          # Only connections
+          connections
+        _ ->
           []
       end
 


### PR DESCRIPTION
It checks `TASK_BUNNY_DISABLE_WORKER` environment variable. If the value is truthy (1, "true", "TRUE", "yes" or "YES") it doesn't start workers.

You might want to separate out worker process from web application while sharing codebase and config file. This will be useful in such case.
