### PR TITLE
Declare queues on start

### DIFF
--- a/lib/task_bunny/connection.ex
+++ b/lib/task_bunny/connection.ex
@@ -202,7 +202,6 @@ defmodule TaskBunny.Connection do
 
   @spec publish_connection(struct, list(pid)) :: :ok
   defp publish_connection(connection, listeners) do
-    Logger.debug "TaskBunny.Connection: publishing to #{inspect listeners}"
     Enum.each listeners, fn (pid) ->
       if Process.alive?(pid), do: send(pid, {:connected, connection})
     end

--- a/lib/task_bunny/initializer.ex
+++ b/lib/task_bunny/initializer.ex
@@ -39,6 +39,14 @@ defmodule TaskBunny.Initializer do
     end
   end
 
+  @doc """
+  Returns true if Initializer process exists
+  """
+  @spec alive?() :: boolean
+  def alive? do
+    Process.whereis(__MODULE__) != nil
+  end
+
   @doc false
   @spec handle_call(atom, {pid, term}, boolean) :: {:reply, boolean, boolean}
   def handle_call(:get_state, _, state) do

--- a/lib/task_bunny/initializer.ex
+++ b/lib/task_bunny/initializer.ex
@@ -1,0 +1,111 @@
+defmodule TaskBunny.Initializer do
+  # Handles initialization concerns.
+  #
+  # This module is private to TaskBunny and should not be accessed directly.
+  #
+  @moduledoc false
+  use GenServer
+  require Logger
+  alias TaskBunny.{Config, Queue}
+
+  @doc false
+  @spec start_link(boolean) :: GenServer.on_start
+  def start_link(initialized \\ false) do
+    GenServer.start_link(__MODULE__, initialized, name: __MODULE__)
+  end
+
+  @doc false
+  @spec init(boolean) :: {:ok, boolean}
+  def init(true) do
+    # Already initialized. Nothing to do.
+    {:ok, true}
+  end
+
+  @doc false
+  @spec init(boolean) :: {:ok, boolean}
+  def init(false) do
+    declare_queues_from_config()
+    {:ok, true}
+  end
+
+  @doc """
+  Returns true if TaskBunny has been initialized
+  """
+  @spec initialized?() :: boolean
+  def initialized? do
+    case Process.whereis(__MODULE__) do
+      nil -> false
+      pid -> GenServer.call(pid, :get_state)
+    end
+  end
+
+  @doc false
+  @spec handle_call(atom, {pid, term}, boolean) :: {:reply, boolean, boolean}
+  def handle_call(:get_state, _, state) do
+    {:reply, state, state}
+  end
+
+  @doc false
+  @spec handle_info(any, boolean) :: {:noreply, boolean}
+  def handle_info({:connected, _conn}, false) do
+    # This is called only on edge case where connection was disconnected.
+    # Since the attempt of subscribe_connection is still valid, Connection
+    # module will send a message.
+    # Try to initialize here.
+    declare_queues_from_config()
+    {:noreply, true}
+  end
+
+  def handle_info({:connected, _conn}, state) do
+    {:noreply, state}
+  end
+
+  @doc """
+  Loads config and declares queues listed
+  """
+  @spec declare_queues_from_config() :: :ok
+  def declare_queues_from_config() do
+    Config.queues
+    |> Enum.each(fn (queue) -> declare_queue(queue) end)
+
+    :ok
+  end
+
+  @spec declare_queue(map) :: :ok
+  defp declare_queue(queue_config) do
+    queue = queue_config[:name]
+    host = queue_config[:host] || :default
+
+    TaskBunny.Connection.subscribe_connection(host, self())
+
+    receive do
+      {:connected, conn} -> declare_queue(conn, queue)
+    after
+      2_000 ->
+        Logger.warn """
+        TaskBunny.Initializer: Failed to get connection for #{host}.
+        TaskBunny can't declare the queues but carries on.
+        """
+    end
+
+    :ok
+  end
+
+  @spec declare_queue(AMQP.Connection.t, String.t) :: :ok
+  defp declare_queue(conn, queue) do
+    Queue.declare_with_subqueues(conn, queue)
+    :ok
+  catch
+    :exit, e ->
+      # Handles the error but we carry on...
+      # It's highly likely caused by the options on queue declare don't match.
+      # We carry on with error log.
+      Logger.warn """
+      TaskBunny.Initializer: Failed to declare queue for #{queue}.
+      If you have changed the queue configuration, you have to delete the queue and create it again.
+      Error: #{inspect e}
+      """
+
+      {:error, {:exit, e}}
+  end
+end

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -197,30 +197,14 @@ defmodule TaskBunny.Job do
 
   @spec do_enqueue(atom, String.t, String.t, nil|integer) :: :ok | {:error, any}
   defp do_enqueue(host, queue, message, nil) do
-    declare_queue(host, queue)
     Publisher.publish!(host, queue, message)
   end
 
   defp do_enqueue(host, queue, message, delay) do
-    declare_queue(host, queue)
     scheduled = Queue.scheduled_queue(queue)
     options = [
       expiration: "#{delay}"
     ]
     Publisher.publish!(host, scheduled, message, options)
-  end
-
-  @spec declare_queue(atom, String.t) :: :ok
-  defp declare_queue(host, queue) do
-    Queue.declare_with_subqueues(host, queue)
-    :ok
-  catch
-    :exit, e ->
-      # Handles the error but we carry on...
-      # It's highly likely caused by the options on queue declare don't match.
-      # We carry on with error log.
-      Logger.error "TaskBunny.job: Failed to declare queue for #{queue}. If you have changed the queue configuration, you have to delete the queue and create it again. Error: #{inspect e}"
-
-      {:error, {:exit, e}}
   end
 end

--- a/lib/task_bunny/queue.ex
+++ b/lib/task_bunny/queue.ex
@@ -102,7 +102,14 @@ defmodule TaskBunny.Queue do
   @doc """
   Returns the message count and consumer count for the given queue.
   """
-  @spec state(%AMQP.Connection{}, String.t) :: map
+  @spec state(%AMQP.Connection{} | atom, String.t) :: map
+  def state(host_or_conn \\ :default, queue)
+
+  def state(host, queue) when is_atom(host) do
+    conn = TaskBunny.Connection.get_connection!(host)
+    state(conn, queue)
+  end
+
   def state(connection, queue) do
     {:ok, channel} = AMQP.Channel.open(connection)
     {:ok, state} = AMQP.Queue.status(channel, queue)

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -29,7 +29,11 @@ defmodule TaskBunny.Supervisor do
       worker(Connection, [host])
     end
 
-    children = connections ++ [worker(Initializer, [false])]
+    children =
+      case Initializer.alive? do
+        true -> connections
+        false -> connections ++ [worker(Initializer, [false])]
+      end
 
     # Define workers and child supervisors to be supervised
     children =

--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -11,7 +11,7 @@ defmodule TaskBunny.Supervisor do
   configure child processes based on configuration file.
   """
   use Supervisor
-  alias TaskBunny.{Connection, Config, WorkerSupervisor}
+  alias TaskBunny.{Connection, Config, Initializer, WorkerSupervisor}
 
   @doc false
   @spec start_link(atom, atom) :: {:ok, pid} | {:error, term}
@@ -29,14 +29,16 @@ defmodule TaskBunny.Supervisor do
       worker(Connection, [host])
     end
 
+    children = connections ++ [worker(Initializer, [false])]
+
     # Define workers and child supervisors to be supervised
     children =
       case {Config.auto_start?, Config.disable_worker?} do
         {true, false} ->
-          connections ++ [supervisor(WorkerSupervisor, [wsv_name])]
+          children ++ [supervisor(WorkerSupervisor, [wsv_name])]
         {true, true} ->
           # Only connections
-          connections
+          children
         _ ->
           []
       end

--- a/test/task_bunny/initializer_test.exs
+++ b/test/task_bunny/initializer_test.exs
@@ -1,0 +1,34 @@
+defmodule TaskBunny.InitializerTest do
+  use ExUnit.Case, async: false
+  import TaskBunny.QueueTestHelper
+  alias TaskBunny.{Config, Initializer, Queue}
+
+  @queue "task_bunny.initializer_test"
+
+  defp queues do
+    [
+      [name: @queue, host: :default]
+    ]
+  end
+
+  setup do
+    clean(Queue.queue_with_subqueues(@queue))
+    :meck.new Config, [:passthrough]
+    :meck.expect Config, :queues, fn () -> queues() end
+
+    on_exit(fn -> :meck.unload end)
+
+    :ok
+  end
+
+  describe "declare_queues_from_config" do
+    test "loads list of queues from config and declares them" do
+      Initializer.declare_queues_from_config()
+      assert Queue.state(@queue) == %{
+        consumer_count: 0,
+        message_count: 0,
+        queue: @queue
+      }
+    end
+  end
+end

--- a/test/task_bunny/job_test.exs
+++ b/test/task_bunny/job_test.exs
@@ -12,6 +12,7 @@ defmodule TaskBunny.JobTest do
 
   setup do
     clean(Queue.queue_with_subqueues(@queue))
+    Queue.declare_with_subqueues(:default, @queue)
 
     :ok
   end

--- a/test/task_bunny/status/worker_test.exs
+++ b/test/task_bunny/status/worker_test.exs
@@ -54,6 +54,9 @@ defmodule TaskBunny.Status.WorkerTest do
     TaskBunny.Supervisor.start_link(@supervisor, @worker_supervisor)
     JobTestHelper.wait_for_connection(@host)
 
+    Queue.declare_with_subqueues(:default, @queue1)
+    Queue.declare_with_subqueues(:default, @queue2)
+
     on_exit fn ->
       :meck.unload
       JobTestHelper.teardown

--- a/test/task_bunny/status_test.exs
+++ b/test/task_bunny/status_test.exs
@@ -21,6 +21,7 @@ defmodule TaskBunny.StatusTest do
 
   setup do
     clean(Queue.queue_with_subqueues(@queue))
+    Queue.declare_with_subqueues(:default, @queue)
 
     mock_config()
     JobTestHelper.setup

--- a/test/task_bunny/supervisor_test.exs
+++ b/test/task_bunny/supervisor_test.exs
@@ -46,6 +46,7 @@ defmodule TaskBunny.SupervisorTest do
 
     TaskBunny.Supervisor.start_link(:supevisor_test, :wsv_supervisor_test)
     JobTestHelper.wait_for_connection(@host)
+    Queue.declare_with_subqueues(:default, @queue)
 
     on_exit fn ->
       :meck.unload

--- a/test/task_bunny/worker_supervisor_test.exs
+++ b/test/task_bunny/worker_supervisor_test.exs
@@ -35,6 +35,7 @@ defmodule TaskBunny.WorkerSupervisorTest do
   setup do
     clean(Queue.queue_with_subqueues(@queue))
     JobTestHelper.setup
+    Queue.declare_with_subqueues(:default, @queue)
 
     :meck.new Config, [:passthrough]
     :meck.expect Config, :workers, fn () -> workers() end

--- a/test/task_bunny/worker_test.exs
+++ b/test/task_bunny/worker_test.exs
@@ -18,6 +18,7 @@ defmodule TaskBunny.WorkerTest do
   setup do
     clean(all_queues())
     JobTestHelper.setup
+    Queue.declare_with_subqueues(:default, @queue)
 
     on_exit fn ->
       JobTestHelper.teardown


### PR DESCRIPTION
`Job.enqueue` will be required to have a higher throughput. Although it is safe to make sure the existence of queues before enqueueing, we can't ignore the overhead.

This PR introduces Initializer module and declares the queues on application start. Then remove the queue declaration from job enqueue.