### PR TITLE
Connection workers are passed a unique id

### DIFF
--- a/lib/task_bunny/supervisor.ex
+++ b/lib/task_bunny/supervisor.ex
@@ -26,7 +26,7 @@ defmodule TaskBunny.Supervisor do
   def init([wsv_name]) do
     # Add Connection severs for each hosts
     connections = Enum.map Config.hosts(), fn (host) ->
-      worker(Connection, [host])
+      worker(Connection, [host], [id: make_ref()])
     end
 
     children =


### PR DESCRIPTION
Using task_bunny I have get error:
```
$ iex -S mix
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Generated dreaming_bunny app

=INFO REPORT==== 23-May-2017::11:33:30 ===
    application: logger
    exited: stopped
    type: temporary
** (Mix) Could not start application task_bunny: TaskBunny.start(:normal, []) returned an error: shutdown: failed to start child: TaskBunny.Supervisor
    ** (EXIT) an exception was raised:
        ** (ArgumentError) duplicated id TaskBunny.Connection found in the supervisor specification, please explicitly pass the :id option when defining this worker/supervisor
            (elixir) lib/supervisor/spec.ex:175: Supervisor.Spec.assert_unique_ids/1
            (elixir) lib/supervisor/spec.ex:169: Supervisor.Spec.supervise/2
            (stdlib) supervisor.erl:294: :supervisor.init/1
            (stdlib) gen_server.erl:328: :gen_server.init_it/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
```
This is possibly related to left-over processes from a crashed session.
It is not an issue if workers are given unique id's.