### PR TITLE
Listeners will not be reset on reconnection to the message broker

### DIFF
--- a/lib/task_bunny/connection.ex
+++ b/lib/task_bunny/connection.ex
@@ -185,7 +185,7 @@ defmodule TaskBunny.Connection do
         Process.monitor(connection.pid)
         publish_connection(connection, listeners)
 
-        {:noreply, {host, connection, []}}
+        {:noreply, {host, connection, listeners}}
       error ->
         Logger.warn "TaskBunny.Connection: failed to connect to #{host} - Error: #{inspect error}. Retrying in #{@reconnect_interval} ms"
         Process.send_after(self(), :connect, @reconnect_interval)


### PR DESCRIPTION
Hi, why are the listeners reset after a reconnection and re-publishing of the connections?
In `def handle_cast({:subscribe_connection, listener}, {host, connection, listeners})` new listeners are added to the state. 
However the callback `def handle_info(:connect, {host, _, listeners})` sets it back to `[]`