### PR TITLE
Failure backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ erl_crash.dump
 *.ez
 
 /logs
+
+# asdf version file
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -416,6 +416,29 @@ All workers will restart automatically once the new connection is established.
 TaskBunny aims to provide zero hassle and recover automatically regardless how
 long the host takes to come back and accessible.
 
+#### Failure backends
+
+By default, when the error occurs during the job execution TaskBunny reports it
+to Logger. If you want to report the error to different services, you can configure
+your custom failure backend.
+
+```elixir
+config :task_bunny, failure_backend: [YourApp.CustomFailureBackend]
+```
+
+You can also report the errors to the multiple backends. For example, if you
+want to use our default Logger backend with your custom backend you can
+configure like below:
+
+```elixir
+config :task_bunny, failure_backend: [
+  TaskBunny.FailureBackend.Logger,
+  YourApp.CustomFailureBackend
+]
+```
+
+Check out the implementation of [TaskBunny.FailureBackend.Logger](https://github.com/shinyscorpion/task_bunny/blob/master/lib/task_bunny/failure_backend/logger.ex) to learn how to write your custom failure backend.
+
 ## Monitoring
 
 #### RabbitMQ plugins

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -189,7 +189,7 @@ defmodule TaskBunny.Config do
   @doc """
   Returns the list of failure backends.
 
-  It returns [TaskBunny.FailureBackend.Logger] by default.
+  It returns `TaskBunny.FailureBackend.Logger` by default.
   """
   @spec failure_backend :: [atom]
   def failure_backend do

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -185,4 +185,18 @@ defmodule TaskBunny.Config do
       _ -> []
     end
   end
+
+  @doc """
+  Returns the list of failure backends.
+
+  It returns [TaskBunny.FailureBackend.Logger] by default.
+  """
+  @spec failure_backend :: [atom]
+  def failure_backend do
+    case Application.fetch_env(:task_bunny, :failure_backend) do
+      {:ok, list} when is_list(list) -> list
+      {:ok, atom} when is_atom(atom) -> [atom]
+      _ -> [TaskBunny.FailureBackend.Logger]
+    end
+  end
 end

--- a/lib/task_bunny/error_reporter.ex
+++ b/lib/task_bunny/error_reporter.ex
@@ -1,0 +1,13 @@
+defmodule TaskBunny.ErrorReporter do
+  @moduledoc """
+  A behaviour module to implment the your own error reporting backend.
+  """
+  alias TaskBunny.JobError
+
+  @doc false
+  @spec report_job_error(JobError.t) :: :ok
+  def report_job_error(job_error) do
+
+    :ok
+  end
+end

--- a/lib/task_bunny/failure_backend.ex
+++ b/lib/task_bunny/failure_backend.ex
@@ -1,6 +1,6 @@
-defmodule TaskBunny.ErrorReporter do
+defmodule TaskBunny.FailureBackend do
   @moduledoc """
-  A behaviour module to implment the your own error reporting backend.
+  A behaviour module to implment the your own failure backend.
   """
   alias TaskBunny.JobError
 

--- a/lib/task_bunny/failure_backend.ex
+++ b/lib/task_bunny/failure_backend.ex
@@ -1,12 +1,54 @@
 defmodule TaskBunny.FailureBackend do
   @moduledoc """
   A behaviour module to implment the your own failure backend.
+
+  Note the backend is called only for the errors caught during job processing.
+  Any other errors won't be reported to the backend.
+
+  ## Configuration
+
+  By default, TaskBunny reports the job failures to Logger.
+  If you want to report the error to different services, you can configure
+  your custom failure backend.
+
+      config :task_bunny, failure_backend: [YourApp.CustomFailureBackend]
+
+  You can also report the errors to the multiple backends. For example, if you
+  want to use our default Logger backend with your custom backend you can
+  configure like below:
+
+      config :task_bunny, failure_backend: [
+        TaskBunny.FailureBackend.Logger,
+        YourApp.CustomFailureBackend
+      ]
+
+  ## Example
+
+  See the implmentation of `TaskBunny.FailureBackend.Logger`.
+
+  ## Argument
+
+  See `TaskBunny.JobError` for the details.
+
   """
-  alias TaskBunny.JobError
+  alias TaskBunny.{JobError, Config, FailureBackend}
+
+  @doc """
+  Callback to report a job error.
+  """
+  @callback report_job_error(JobError.t) :: any
+
+  defmacro __using__(_options \\ []) do
+    quote do
+      @behaviour FailureBackend
+    end
+  end
 
   @doc false
   @spec report_job_error(JobError.t) :: :ok
-  def report_job_error(job_error) do
+  def report_job_error(job_error = %JobError{}) do
+    Config.failure_backend()
+    |> Enum.each(&(&1.report_job_error(job_error)))
 
     :ok
   end

--- a/lib/task_bunny/failure_backend.ex
+++ b/lib/task_bunny/failure_backend.ex
@@ -1,6 +1,6 @@
 defmodule TaskBunny.FailureBackend do
   @moduledoc """
-  A behaviour module to implment the your own failure backend.
+  A behaviour module to implement the your own failure backend.
 
   Note the backend is called only for the errors caught during job processing.
   Any other errors won't be reported to the backend.
@@ -49,7 +49,5 @@ defmodule TaskBunny.FailureBackend do
   def report_job_error(job_error = %JobError{}) do
     Config.failure_backend()
     |> Enum.each(&(&1.report_job_error(job_error)))
-
-    :ok
   end
 end

--- a/lib/task_bunny/failure_backend/logger.ex
+++ b/lib/task_bunny/failure_backend/logger.ex
@@ -1,0 +1,99 @@
+defmodule TaskBunny.FailureBackend.Logger do
+  @moduledoc """
+  Default failure backend that reports job errors to Logger.
+  """
+  use TaskBunny.FailureBackend
+  require Logger
+  alias TaskBunny.JobError
+
+  def report_job_error(error = %JobError{error_type: :exception}) do
+    message = """
+    TaskBunny - #{error.job} failed for an exception.
+
+    Exception:
+    #{my_inspect error.exception}
+
+    #{common_message error}
+
+    Stacktrace:
+    #{Exception.format_stacktrace(error.stacktrace)}
+    """
+
+    do_report(message, error.reject)
+  end
+
+  def report_job_error(error = %JobError{error_type: :return_value}) do
+    message = """
+    TaskBunny - #{error.job} failed for an invalid return value.
+
+    Return value:
+    #{my_inspect error.return_value}
+
+    #{common_message error}
+    """
+
+    do_report(message, error.reject)
+  end
+
+  def report_job_error(error = %JobError{error_type: :exit}) do
+    message = """
+    TaskBunny - #{error.job} failed for EXIT signal.
+
+    Reason:
+    #{my_inspect error.reason}
+
+    #{common_message error}
+    """
+
+    do_report(message, error.reject)
+  end
+
+  def report_job_error(error = %JobError{error_type: :timeout}) do
+    message = """
+    TaskBunny - #{error.job} failed for timeout.
+
+    #{common_message error}
+    """
+
+    do_report(message, error.reject)
+  end
+
+  def report_job_error(error) do
+    message = """
+    TaskBunny - Failed with the unknown error type.
+
+    Error dump:
+    #{my_inspect error}
+    """
+
+    do_report(message, true)
+  end
+
+  defp do_report(message, rejected) do
+    if rejected do
+      Logger.error message
+    else
+      Logger.warn message
+    end
+  end
+
+  defp common_message(error) do
+    """
+    Payload:
+      #{my_inspect error.payload}
+
+    History:
+      - Failed count: #{error.failed_count}
+      - Reject: #{error.reject}
+
+    Worker:
+      - Queue: #{error.queue}
+      - Concurrency: #{error.concurrency}
+      - PID: #{inspect error.pid}
+    """
+  end
+
+  defp my_inspect(arg) do
+    inspect arg, pretty: true, width: 100
+  end
+end

--- a/lib/task_bunny/failure_backend/logger.ex
+++ b/lib/task_bunny/failure_backend/logger.ex
@@ -7,7 +7,7 @@ defmodule TaskBunny.FailureBackend.Logger do
   alias TaskBunny.JobError
 
   def report_job_error(error = %JobError{error_type: :exception}) do
-    message = """
+    """
     TaskBunny - #{error.job} failed for an exception.
 
     Exception:
@@ -18,12 +18,11 @@ defmodule TaskBunny.FailureBackend.Logger do
     Stacktrace:
     #{Exception.format_stacktrace(error.stacktrace)}
     """
-
-    do_report(message, error.reject)
+    |> do_report(error.reject)
   end
 
   def report_job_error(error = %JobError{error_type: :return_value}) do
-    message = """
+    """
     TaskBunny - #{error.job} failed for an invalid return value.
 
     Return value:
@@ -31,12 +30,11 @@ defmodule TaskBunny.FailureBackend.Logger do
 
     #{common_message error}
     """
-
-    do_report(message, error.reject)
+    |> do_report(error.reject)
   end
 
   def report_job_error(error = %JobError{error_type: :exit}) do
-    message = """
+    """
     TaskBunny - #{error.job} failed for EXIT signal.
 
     Reason:
@@ -44,29 +42,26 @@ defmodule TaskBunny.FailureBackend.Logger do
 
     #{common_message error}
     """
-
-    do_report(message, error.reject)
+    |> do_report(error.reject)
   end
 
   def report_job_error(error = %JobError{error_type: :timeout}) do
-    message = """
+    """
     TaskBunny - #{error.job} failed for timeout.
 
     #{common_message error}
     """
-
-    do_report(message, error.reject)
+    |> do_report(error.reject)
   end
 
   def report_job_error(error) do
-    message = """
+    """
     TaskBunny - Failed with the unknown error type.
 
     Error dump:
     #{my_inspect error}
     """
-
-    do_report(message, true)
+    |> do_report(true)
   end
 
   defp do_report(message, rejected) do

--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -1,6 +1,24 @@
 defmodule TaskBunny.JobError do
   @moduledoc """
-  A struct that holds an error information occured at the job execution.
+  A struct that holds an error information occured during the job processing.
+
+  ## Attributes
+
+  - job: the job module failed
+  - payload: the payload(arguments) for the job execution
+  - error_type: the type of the error. :exception, :return_value, :timeout or :exit
+  - exception: the inner exception (option)
+  - stacktrace: the stacktrace (only available for the exception)
+  - return_value: the return value from the job (only available for the return value error)
+  - reason: the reason information passed with EXIT signal (only available for exit error)
+  - raw_body: the raw body for the message
+  - meta: the meta data given by RabbitMQ
+  - failed_count: the number of failures for the job processing request
+  - queue: the name of the queue
+  - concurrency: the number of concurrent job processing of the worker
+  - pid: the process ID of the worker
+  - reject: sets true if the job is rejected for the failure (means it won't be retried again)
+
   """
 
   @type t :: %__MODULE__{
@@ -9,6 +27,7 @@ defmodule TaskBunny.JobError do
     error_type: :exception | :return_value | :timeout | :exit | nil,
     exception: struct | nil,
     stacktrace: list(tuple) | nil,
+    return_value: any,
     reason: any,
     raw_body: String.t,
     meta: map,

--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -6,24 +6,34 @@ defmodule TaskBunny.JobError do
   @type t :: %__MODULE__{
     job: atom,
     payload: any,
-    raw_body: String.t,
-    meta: map,
     error_type: :exception | :return_value | :timeout | :exit | nil,
     exception: struct | nil,
     stacktrace: list(tuple) | nil,
-    reason: any
+    reason: any,
+    raw_body: String.t,
+    meta: map,
+    failed_count: integer,
+    queue: String.t,
+    concurrency: integer,
+    pid: pid,
+    reject: boolean
   }
 
   defstruct [
     job: nil,
     payload: nil,
-    raw_body: "",
-    meta: %{},
     error_type: nil,
     exception: nil,
     stacktrace: nil,
     return_value: nil,
-    reason: nil
+    reason: nil,
+    raw_body: "",
+    meta: %{},
+    failed_count: 0,
+    queue: "",
+    concurrency: 1,
+    pid: nil,
+    reject: false
   ]
 
   @doc false

--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -22,7 +22,7 @@ defmodule TaskBunny.JobError do
   """
 
   @type t :: %__MODULE__{
-    job: atom,
+    job: atom | nil,
     payload: any,
     error_type: :exception | :return_value | :timeout | :exit | nil,
     exception: struct | nil,
@@ -34,7 +34,7 @@ defmodule TaskBunny.JobError do
     failed_count: integer,
     queue: String.t,
     concurrency: integer,
-    pid: pid,
+    pid: pid | nil,
     reject: boolean
   }
 
@@ -56,6 +56,7 @@ defmodule TaskBunny.JobError do
   ]
 
   @doc false
+  @spec handle_exception(atom, any, struct) :: t
   def handle_exception(job, payload, exception) do
     %__MODULE__{
       job: job,
@@ -67,6 +68,7 @@ defmodule TaskBunny.JobError do
   end
 
   @doc false
+  @spec handle_exit(atom, any, any) :: t
   def handle_exit(job, payload, reason) do
     %__MODULE__{
       job: job,
@@ -77,6 +79,7 @@ defmodule TaskBunny.JobError do
   end
 
   @doc false
+  @spec handle_return_value(atom, any, any) :: t
   def handle_return_value(job, payload, return_value) do
     %__MODULE__{
       job: job,
@@ -87,6 +90,7 @@ defmodule TaskBunny.JobError do
   end
 
   @doc false
+  @spec handle_timeout(atom, any) :: t
   def handle_timeout(job, payload) do
     %__MODULE__{
       job: job,

--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -1,0 +1,68 @@
+defmodule TaskBunny.JobError do
+  @moduledoc """
+  A struct that holds an error information occured at the job execution.
+  """
+
+  @type t :: %__MODULE__{
+    job: atom,
+    payload: any,
+    raw_body: String.t,
+    meta: map,
+    error_type: :exception | :return_value | :timeout | :exit | nil,
+    exception: struct | nil,
+    stacktrace: list(tuple) | nil,
+    reason: any
+  }
+
+  defstruct [
+    job: nil,
+    payload: nil,
+    raw_body: "",
+    meta: %{},
+    error_type: nil,
+    exception: nil,
+    stacktrace: nil,
+    return_value: nil,
+    reason: nil
+  ]
+
+  @doc false
+  def handle_exception(job, payload, exception) do
+    %__MODULE__{
+      job: job,
+      payload: payload,
+      error_type: :exception,
+      exception: exception,
+      stacktrace: System.stacktrace()
+    }
+  end
+
+  @doc false
+  def handle_exit(job, payload, reason) do
+    %__MODULE__{
+      job: job,
+      payload: payload,
+      error_type: :exit,
+      reason: reason
+    }
+  end
+
+  @doc false
+  def handle_return_value(job, payload, return_value) do
+    %__MODULE__{
+      job: job,
+      payload: payload,
+      error_type: :return_value,
+      return_value: return_value
+    }
+  end
+
+  @doc false
+  def handle_timeout(job, payload) do
+    %__MODULE__{
+      job: job,
+      payload: payload,
+      error_type: :timeout
+    }
+  end
+end

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -10,7 +10,7 @@ defmodule TaskBunny.Worker do
   use GenServer
   require Logger
   alias TaskBunny.{Connection, Consumer, JobRunner, Queue,
-                   Publisher, Worker, Message, ErrorReporter}
+                   Publisher, Worker, Message, FailureBackend}
 
   @typedoc """
   Struct that represents a state of the worker GenServer.
@@ -227,7 +227,7 @@ defmodule TaskBunny.Worker do
          pid: self(),
          reject: failed_count > job.max_retry()
        })
-    |> ErrorReporter.report_job_error()
+    |> FailureBackend.report_job_error()
 
     if failed_count <= job.max_retry() do
       retry_message(job, state, new_body, meta, failed_count)

--- a/test/task_bunny/failure_backend/logger_test.exs
+++ b/test/task_bunny/failure_backend/logger_test.exs
@@ -1,0 +1,62 @@
+defmodule TaskBunny.FailureBackend.LoggerTest do
+  use ExUnit.Case, async: false
+  alias TaskBunny.JobError
+  import TaskBunny.FailureBackend.Logger
+  import ExUnit.CaptureLog
+
+  @job_error %JobError{
+    job: TestJob, payload: %{"test" => 1}, reject: false,
+    failed_count: 1, queue: "test_queue", pid: self(),
+  }
+
+  @exception_error Map.merge(@job_error, %{
+    error_type: :exception, exception: RuntimeError.exception("Hello"),
+    stacktrace: System.stacktrace()
+  })
+
+  @return_value_error Map.merge(@job_error, %{
+    error_type: :return_value, return_value: {:error, :testing}
+  })
+
+  @exit_error Map.merge(@job_error, %{
+    error_type: :exit, reason: :just_testing
+  })
+
+  @timeout_error Map.merge(@job_error, %{
+    error_type: :timeout
+  })
+
+  @unexpected_error "This should not be passed"
+
+  describe "report_job_error/1" do
+    test "handles an exception" do
+      assert capture_log(fn ->
+        report_job_error @exception_error
+      end) =~ "TaskBunny - Elixir.TestJob failed for an exception"
+    end
+
+    test "handles an invalid return value" do
+      assert capture_log(fn ->
+        report_job_error @return_value_error
+      end) =~ "TaskBunny - Elixir.TestJob failed for an invalid return value"
+    end
+
+    test "handles the EXIT signal" do
+      assert capture_log(fn ->
+        report_job_error @exit_error
+      end) =~ "TaskBunny - Elixir.TestJob failed for EXIT signal"
+    end
+
+    test "handles timeout" do
+      assert capture_log(fn ->
+        report_job_error @timeout_error
+      end) =~ "TaskBunny - Elixir.TestJob failed for timeout"
+    end
+
+    test "handles non JobError just in case" do
+      assert capture_log(fn ->
+        report_job_error @unexpected_error
+      end) =~ "TaskBunny - Failed with the unknown error type"
+    end
+  end
+end

--- a/test/task_bunny/failure_backend_test.exs
+++ b/test/task_bunny/failure_backend_test.exs
@@ -1,0 +1,48 @@
+defmodule TaskBunny.FailureBackendTest do
+  use ExUnit.Case, async: false
+  alias TaskBunny.{JobError, FailureBackend}
+  import ExUnit.{CaptureLog, CaptureIO}
+
+  defp setup_failure_backend_config(failure_backend) do
+    :meck.new Application, [:passthrough]
+    :meck.expect Application, :fetch_env, fn(:task_bunny, :failure_backend) ->
+      {:ok, failure_backend}
+    end
+
+    on_exit fn -> :meck.unload end
+  end
+
+  defmodule TestBackend do
+    use FailureBackend
+
+    def report_job_error(error) do
+      IO.puts "Hello #{error.job}"
+    end
+  end
+
+  @job_error %JobError{
+    job: TestJob, payload: %{"test" => 1}, reject: false,
+    failed_count: 1, queue: "test_queue", pid: self(),
+  }
+
+  @exception_error Map.merge(@job_error, %{
+    error_type: :exception, exception: RuntimeError.exception("Hello"),
+    stacktrace: System.stacktrace()
+  })
+
+  describe "report_job_error/1" do
+    test "reports to Logger backend by default" do
+      assert capture_log(fn ->
+        FailureBackend.report_job_error @exception_error
+      end) =~ "TaskBunny - Elixir.TestJob failed for an exception"
+    end
+
+    test "reports to the custom backend" do
+      setup_failure_backend_config([TestBackend])
+
+      assert capture_io(fn ->
+        FailureBackend.report_job_error @exception_error
+      end) =~ "Hello Elixir.TestJob"
+    end
+  end
+end

--- a/test/task_bunny/job_runner_test.exs
+++ b/test/task_bunny/job_runner_test.exs
@@ -71,7 +71,7 @@ defmodule TaskBunny.JobRunnerTest do
     test "handles job error" do
       JobRunner.invoke(SampleJobs.ErrorJob, nil, nil)
 
-      assert_receive {:job_finished, {:error, "failed!"}, nil}
+      assert_receive {:job_finished, {:error, %{return_value: {:error, "failed!"}}}, nil}
     end
 
     test "handles job crashing" do


### PR DESCRIPTION
The change allows you to implement/configure custom job failure backends.

```elixir
config :task_bunny, failure_backend: [
  TaskBunny.FailureBackend.Logger,
  YourApp.CustomFailureBackend
]
```

This will allow you to send the error report to your choice of services such as Rollbar, Airbrake, Bugsnag, Raygun etc... with the richer information.

We are also planning to release Rollbar backend as a separate hex library sometime in the next week.