### PR TITLE
Expose `TaskBunny.FailureBackend.Logger.get_job_error_message/1`

### DIFF
--- a/lib/task_bunny/failure_backend/logger.ex
+++ b/lib/task_bunny/failure_backend/logger.ex
@@ -6,7 +6,17 @@ defmodule TaskBunny.FailureBackend.Logger do
   require Logger
   alias TaskBunny.JobError
 
-  def report_job_error(error = %JobError{error_type: :exception}) do
+  # Callback for FailureBackend
+  def report_job_error(error = %JobError{}) do
+    get_job_error_message(error)
+    |> do_report(error.reject)
+  end
+
+  @doc """
+  Returns the message content for the job error.
+  """
+  @spec get_job_error_message(JobError.t) :: String.t
+  def get_job_error_message(error = %JobError{error_type: :exception}) do
     """
     TaskBunny - #{error.job} failed for an exception.
 
@@ -18,10 +28,9 @@ defmodule TaskBunny.FailureBackend.Logger do
     Stacktrace:
     #{Exception.format_stacktrace(error.stacktrace)}
     """
-    |> do_report(error.reject)
   end
 
-  def report_job_error(error = %JobError{error_type: :return_value}) do
+  def get_job_error_message(error = %JobError{error_type: :return_value}) do
     """
     TaskBunny - #{error.job} failed for an invalid return value.
 
@@ -30,10 +39,9 @@ defmodule TaskBunny.FailureBackend.Logger do
 
     #{common_message error}
     """
-    |> do_report(error.reject)
   end
 
-  def report_job_error(error = %JobError{error_type: :exit}) do
+  def get_job_error_message(error = %JobError{error_type: :exit}) do
     """
     TaskBunny - #{error.job} failed for EXIT signal.
 
@@ -42,26 +50,22 @@ defmodule TaskBunny.FailureBackend.Logger do
 
     #{common_message error}
     """
-    |> do_report(error.reject)
   end
 
-  def report_job_error(error = %JobError{error_type: :timeout}) do
+  def get_job_error_message(error = %JobError{error_type: :timeout}) do
     """
     TaskBunny - #{error.job} failed for timeout.
 
     #{common_message error}
     """
-    |> do_report(error.reject)
   end
 
-  def report_job_error(error) do
+  def get_job_error_message(error = %JobError{}) do
     """
     TaskBunny - Failed with the unknown error type.
 
-    Error dump:
-    #{my_inspect error}
+    #{common_message error}
     """
-    |> do_report(true)
   end
 
   defp do_report(message, rejected) do

--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -74,7 +74,8 @@ defmodule TaskBunny.JobError do
       job: job,
       payload: payload,
       error_type: :exit,
-      reason: reason
+      reason: reason,
+      stacktrace: System.stacktrace()
     }
   end
 

--- a/test/task_bunny/failure_backend/logger_test.exs
+++ b/test/task_bunny/failure_backend/logger_test.exs
@@ -26,7 +26,9 @@ defmodule TaskBunny.FailureBackend.LoggerTest do
     error_type: :timeout
   })
 
-  @unexpected_error "This should not be passed"
+  @unknown_error Map.merge(@job_error, %{
+    error_type: :invalid_type
+  })
 
   describe "report_job_error/1" do
     test "handles an exception" do
@@ -53,9 +55,9 @@ defmodule TaskBunny.FailureBackend.LoggerTest do
       end) =~ "TaskBunny - Elixir.TestJob failed for timeout"
     end
 
-    test "handles non JobError just in case" do
+    test "handles unknown error type" do
       assert capture_log(fn ->
-        report_job_error @unexpected_error
+        report_job_error @unknown_error
       end) =~ "TaskBunny - Failed with the unknown error type"
     end
   end


### PR DESCRIPTION
By default, the Logger backend uses `warn` for non rejected failures and `error` for rejected failures. The strategy might not fit for your application but you might want to still reuse the message format logic. For example, if you report the errors to other backend you might want to log the error with `info` level in your custom failure backend.

```elixir
defmodule CustomFailureBackend do
  use TaskBunny.FailureBackend
  require Logger
  alias TaskBunny.FailureBackend.Logger, as: LoggerBackend

  def report_job_error(error) do
    #
    # ... your custom reporting logic here
    #

    Logger.info LoggerBackend.get_job_error_message(error)
  end
end
```