### PR TITLE
Fix perform callback typespec

### DIFF
--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -85,7 +85,7 @@ defmodule TaskBunny.Job do
       end
 
   """
-  @callback perform(any) :: :ok | {:error, term}
+  @callback perform(any) :: :ok | {:ok, any} | {:error, term}
 
   @doc """
   Callback for the timeout in milliseconds for a job execution.


### PR DESCRIPTION
Just a small PR, fixing `TaskBunny.Job.perform` typespec.