### PR TITLE
Feature: Disable worker invalid concurrency

### DIFF
--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -71,7 +71,7 @@ defmodule TaskBunny.Config do
   @spec workers :: [keyword]
   def workers do
     queues()
-    |> Enum.filter(fn (queue) -> queue[:worker] != false end)
+    |> Enum.filter(&worker_enabled?/1)
     |> Enum.map(fn (queue) ->
       concurrency =
         if queue[:worker] && queue[:worker][:concurrency] do
@@ -86,6 +86,18 @@ defmodule TaskBunny.Config do
         host: queue[:host] || :default
       ]
     end)
+  end
+
+  # Checks worker configuration sanity.
+  @spec worker_enabled?(keyword) :: boolean
+  defp worker_enabled?(queue) do
+    case Keyword.get(queue, :worker, []) do
+      false -> false
+      worker ->
+        concurrency = Keyword.get(worker, :concurrency, @default_concurrency)
+
+        concurrency > 0
+    end
   end
 
   @doc """

--- a/mix.lock
+++ b/mix.lock
@@ -13,7 +13,7 @@
   "inch_ex": {:hex, :inch_ex, "0.5.6", "418357418a553baa6d04eccd1b44171936817db61f4c0840112b420b8e378e67", [:mix], [{:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [:mix, :rebar3], [], "hexpm"},
   "logger_file_backend": {:hex, :logger_file_backend, "0.0.9", "5c2f7d4a28431e695cdf94d191523dbafe609321a67bb654254897f546c393db", [:mix], [], "hexpm"},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], [], "hexpm"},
+  "meck": {:hex, :meck, "0.8.8", "eeb3efe811d4346e1a7f65b2738abc2ad73cbe1a2c91b5dd909bac2ea0414fa6", [:rebar3], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/task_bunny/config_test.exs
+++ b/test/task_bunny/config_test.exs
@@ -9,7 +9,8 @@ defmodule TaskBunny.ConfigTest do
         queues: [
           [name: "high", worker: [concurrency: 10], jobs: ["High.*"]],
           [name: "normal", jobs: :default],
-          [name: "low", worker: false, jobs: [SlowJob]]
+          [name: "low", worker: false, jobs: [SlowJob]],
+          [name: "disabled", worker: [concurrency: 0], jobs: :default]
         ]
       ],
       extra_queue: [
@@ -35,7 +36,7 @@ defmodule TaskBunny.ConfigTest do
       queue_names = Config.queues
                     |> Enum.map(fn (queue) -> queue[:name] end)
 
-      assert queue_names == ["test.high", "test.normal", "test.low", "extra.queue1"]
+      assert queue_names == ["test.high", "test.normal", "test.low", "test.disabled", "extra.queue1"]
     end
   end
 


### PR DESCRIPTION
Disable workers that have a less than `1` concurrency set.
(Also disabled workers without concurrency set, if the default (`@default_concurrency`) is less than `1`.)