### PR TITLE
Reply to handling

### DIFF
--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -171,7 +171,7 @@ defmodule TaskBunny.Job do
   - host: RabbitMQ host. By default it is automatically selected from configuration.
   - queue: RabbitMQ queue. By default it is automatically selected from configuration.
   - reply_to: sets the reply_to header and responds to that queue with the outcome of the job
-  - corr_id: sets a cerrelation ID that can be used to match jobs on the client side
+  - correlation_id: sets a cerrelation ID that can be used to match jobs on the client side
 
   """
   @spec enqueue(atom, any, keyword) :: :ok | {:error, any}
@@ -193,11 +193,7 @@ defmodule TaskBunny.Job do
     {:ok, message} = Message.encode(job, payload)
 
     # mapping options
-    opts = %{}
-    |> add_delay(options)
-    |> add_reply_to(options)
-    |> add_corr_id(options)
-
+    opts = map_options(options)
     Logger.info("Options after modding: #{inspect opts}")
     case options[:queue] || queue_data[:name] do
       nil -> raise QueueNotFoundError, job: job
@@ -216,6 +212,12 @@ defmodule TaskBunny.Job do
 
   # explicitly map options to make sure we only have approved data in our
   # messages
+  defp map_options(options) do
+    %{}
+    |> add_delay(options)
+    |> add_reply_to(options)
+    |> add_corr_id(options)
+  end
   defp add_delay(map, options) do
     case options[:delay] do
       nil -> map
@@ -229,7 +231,7 @@ defmodule TaskBunny.Job do
     end
   end
   defp add_corr_id(map, options) do
-    case options[:corr_id] do
+    case options[:correlation_id] do
       nil -> map
       id -> Map.merge(map, %{correlation_id: id})
     end

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -171,6 +171,8 @@ defmodule TaskBunny.Job do
   - host: RabbitMQ host. By default it is automatically selected from configuration.
   - queue: RabbitMQ queue. By default it is automatically selected from configuration.
 
+  TODO: add reply_to option that is handled in the AMQP header
+
   """
   @spec enqueue(atom, any, keyword) :: :ok | {:error, any}
   def enqueue(job, payload, options \\ []) do

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -190,14 +190,17 @@ defmodule TaskBunny.Job do
     queue_data = Config.queue_for_job(job) || []
 
     host = options[:host] || queue_data[:host] || :default
-    {:ok, message} = Message.encode(job, payload)
-
-    # mapping options
-    opts = map_options(options)
-    Logger.info("Options after modding: #{inspect opts}")
-    case options[:queue] || queue_data[:name] do
-      nil -> raise QueueNotFoundError, job: job
-      queue -> do_enqueue(host, queue, message, opts)
+    case Message.encode(job, payload) do
+      {:ok, message} ->
+        opts = map_options(options)
+        Logger.info("Options after modding: #{inspect opts}")
+        case options[:queue] || queue_data[:name] do
+          nil -> raise QueueNotFoundError, job: job
+          queue -> do_enqueue(host, queue, message, opts)
+        end
+      error ->
+        Logger.error("#{inspect error}")
+        error
     end
   end
 

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -140,6 +140,9 @@ defmodule TaskBunny.Worker do
       {:ok, decoded} ->
         Logger.debug log_msg("basic_deliver", state, [body: body])
 
+        # FIXME 
+        # - capture outcome of job runner
+        # - implement RPC option
         JobRunner.invoke(decoded["job"], decoded["payload"], {body, meta})
 
         {:noreply, %{state | runners: state.runners + 1}}

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -166,7 +166,9 @@ defmodule TaskBunny.Worker do
           reply_to ->
             {:ok, message} = result
             Logger.debug log_msg("Replying to :#{reply_to} with #{inspect message}", state, [meta: meta])
-            TaskBunny.Job.enqueue!(String.to_atom(reply_to), %{"ok" => message})
+            opts = map_options(meta)
+            Logger.info("Found the following options: #{inspect opts} from this meta: #{inspect meta}")
+            TaskBunny.Job.enqueue!(String.to_atom(reply_to), %{"ok" => message}, opts)
         end
         {:noreply, update_job_stats(state, :succeeded)}
       false ->
@@ -272,5 +274,12 @@ defmodule TaskBunny.Worker do
     else
       message
     end
+  end
+
+  defp map_options(meta) do
+    fields = [:app_id, :cluster_id, :correlation_id, :content_type,
+              :content_encoding, :headers, :priority, :timestamp, :type,
+              :user_id]
+    Enum.filter(meta, fn({x, _}) -> x in fields end)
   end
 end

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -165,7 +165,7 @@ defmodule TaskBunny.Worker do
 
         unless meta[:reply_to] == :undefined do
           Logger.debug log_msg("reply to #{meta[:reply_to]}", state)
-          respond(result, meta, meta[:reply_to])
+          respond(result, meta)
         end
         {:noreply, update_job_stats(state, :succeeded)}
       false ->
@@ -273,16 +273,16 @@ defmodule TaskBunny.Worker do
     end
   end
 
-  defp respond(:ok, meta, queue) do
+  defp respond(:ok, meta) do
     message = %{"status" => "ok"}
-    respond({:ok, message}, meta, queue)
+    respond({:ok, message}, meta)
   end
-  defp respond({:ok, message}, meta, queue) do
+  defp respond({:ok, message}, meta) do
     opts = map_options(meta)
     meta2 = Enum.reduce(meta, %{}, fn({x, y}, acc) ->
       Map.put(acc, encode_meta(x), encode_meta(y)) end)
     message2 = Map.put(message, "meta", meta2)
-    TaskBunny.Job.enqueue!(String.to_atom(queue), message2, opts)
+    TaskBunny.Job.enqueue!(String.to_atom(meta[:reply_to]), message2, opts)
   end
 
   defp encode_meta(x) when is_atom(x) do


### PR DESCRIPTION
This is the first version of `reply_to` handling. It uses the `reply_to` option in AMQP to tell the worker where the outcome of a job should be written to.

It has stubs for `correlation_id` handling as well but they are not fully handed through the system yet.