### PR TITLE
Fix enqueue! typespec

### DIFF
--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -131,7 +131,7 @@ defmodule TaskBunny.Job do
       end
 
       @doc false
-      @spec enqueue!(any, keyword) :: :ok | {:error, any}
+      @spec enqueue!(any, keyword) :: :ok
       def enqueue!(payload, options \\ []) do
         TaskBunny.Job.enqueue!(__MODULE__, payload, options)
       end
@@ -196,7 +196,7 @@ defmodule TaskBunny.Job do
     end
   end
 
-  @spec do_enqueue(atom, String.t, String.t, nil|integer) :: :ok | {:error, any}
+  @spec do_enqueue(atom, String.t, String.t, nil|integer) :: :ok
   defp do_enqueue(host, queue, message, nil) do
     Publisher.publish!(host, queue, message)
   end


### PR DESCRIPTION
It seems that dialyzer is not checking this typespec. Its probably
related to macros but I'm not entirely sure. `TaskBunny.Job.enqueue!`
spec clearly says that only return value is :ok.

This was discovered when using this library in an application:
```
lib/transporter/delivery_requests/delivery_job.ex:5: The specification
for 'Elixir.Transporter.DeliveryRequests.DeliveryJob':'enqueue!'/2
  states that the function might also return {'error',_} but the
  inferred return is 'ok'
```