### PR TITLE
Bugfix: add worker information to error

### DIFF
--- a/lib/task_bunny/job_error.ex
+++ b/lib/task_bunny/job_error.ex
@@ -55,6 +55,26 @@ defmodule TaskBunny.JobError do
     reject: false
   ]
 
+  @doc """
+  Take information related to the result and make some of them JSON encode safe.
+
+  Since raw body can be bigger as you retry, you do not want to put the information.
+  """
+  @spec get_result_info(t) :: map()
+  def get_result_info(job_error) do
+    Map.take(job_error, [
+      :error_type,
+      :exception,
+      :stacktrace,
+      :return_value,
+      :reason,
+      :failed_count,
+      :queue
+    ])
+    |> Enum.map(fn ({k, v}) -> {k, inspect(v)} end)
+    |> Map.new
+  end
+
   @doc false
   @spec handle_exception(atom, any, struct) :: t
   def handle_exception(job, payload, exception) do

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -9,6 +9,7 @@ defmodule TaskBunny.Message do
   this module will help.
   """
   alias TaskBunny.Message.DecodeError
+  alias TaskBunny.JobError
 
   @doc """
   Encode message body in JSON with job and argument.
@@ -96,10 +97,10 @@ defmodule TaskBunny.Message do
   @doc """
   Add an error log to message body.
   """
-  @spec add_error_log(String.t|map, any) :: String.t | map
+  @spec add_error_log(String.t|map, JobError.t) :: String.t | map
   def add_error_log(message, error) when is_map(message) do
     error = %{
-      "result" => inspect(error),
+      "result" => JobError.get_result_info(error),
       "failed_at" => DateTime.utc_now(),
       "host" => host(),
       "pid" => inspect(self())

--- a/test/task_bunny/failure_backend_test.exs
+++ b/test/task_bunny/failure_backend_test.exs
@@ -25,15 +25,17 @@ defmodule TaskBunny.FailureBackendTest do
     failed_count: 1, queue: "test_queue", pid: self(),
   }
 
-  @exception_error Map.merge(@job_error, %{
-    error_type: :exception, exception: RuntimeError.exception("Hello"),
-    stacktrace: System.stacktrace()
-  })
+  defp exception_error do
+    Map.merge(@job_error, %{
+      error_type: :exception, exception: RuntimeError.exception("Hello"),
+      stacktrace: System.stacktrace()
+    })
+  end
 
   describe "report_job_error/1" do
     test "reports to Logger backend by default" do
       assert capture_log(fn ->
-        FailureBackend.report_job_error @exception_error
+        FailureBackend.report_job_error exception_error()
       end) =~ "TaskBunny - Elixir.TestJob failed for an exception"
     end
 
@@ -41,7 +43,7 @@ defmodule TaskBunny.FailureBackendTest do
       setup_failure_backend_config([TestBackend])
 
       assert capture_io(fn ->
-        FailureBackend.report_job_error @exception_error
+        FailureBackend.report_job_error exception_error()
       end) =~ "Hello Elixir.TestJob"
     end
   end


### PR DESCRIPTION
TaskBunny adds error information to message body when it retries.

https://github.com/shinyscorpion/task_bunny/blob/master/lib/task_bunny/message.ex#L102

However it doesn't contain information like failed_count, queue, concurrency etc. This PR fixes the issue.