### PR TITLE
Added possibility to job run without timeouts constraints

### DIFF
--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -141,6 +141,7 @@ defmodule TaskBunny.Job do
 
       # Returns timeout (default 2 minutes).
       # Override the method to change the timeout.
+      # If timeout is not applicable then override the method with :infinity.
       @doc false
       @spec timeout() :: integer
       def timeout, do: 120_000

--- a/test/task_bunny/job_runner_test.exs
+++ b/test/task_bunny/job_runner_test.exs
@@ -22,6 +22,16 @@ defmodule TaskBunny.JobRunnerTest do
       end
     end
 
+    defmodule InfinityJob do
+      use TaskBunny.Job
+
+      def timeout, do: :infinity
+
+      def perform(_payload) do
+        :ok
+      end
+    end
+
     defmodule NormalJob do
       use TaskBunny.Job
 
@@ -84,6 +94,12 @@ defmodule TaskBunny.JobRunnerTest do
       JobRunner.invoke(SampleJobs.TimeoutJob, nil, nil)
 
       assert_receive {:job_finished, {:error, _}, nil}, 1000
+    end
+
+    test "handles job with infinity timeout" do
+      JobRunner.invoke(SampleJobs.InfinityJob, nil, nil)
+      
+      assert_receive {:job_finished, :ok, _}
     end
   end
 end


### PR DESCRIPTION
I've encounted a scenario where I don't really known how much time the task will take. Thus defining a timeout could kill my job even when "everything is ok".

So this PR just add the possibility to the job run freely. I known this can be dangerous, but it's up to the developer use it or not.