### PR TITLE
Job ID and Life-cycle Callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,24 +330,7 @@ You can also change the retry_interval by the number of failures.
 
 If a job fails more than `max_retry` times, the payload is sent to `jobs.[job_name].rejected` queue.
 
-When a job gets rejected the `on_reject` callback is called. By default it does nothing but you can override it.
-It's useful to execute recovery actions when a job fails (like sending an email to a customer for instance)
-
-It receives the body containing the payload of the rejected job plus the full error trace. It returns :ok
-
-```elixir
-defmodule FlakyJob do
-  use TaskBunny.Job
-  require Logger
-
-  def on_reject(_body) do
-     ...
-
-     :ok
-  end
-  ...
-end
-```
+When a job gets rejected the `on_reject` callback is called. See _Callbacks_ below for more information.
 
 #### Immediately Reject
 
@@ -370,6 +353,36 @@ defmodule SlowJob do
   ...
 end
 ```
+
+## Callbacks
+
+TaskBunny reports job transitions via callbacks:
+
+* `on_start` - called when the job starts
+* `on_success` - called when the job succeeds
+* `on_retry` - called when the job is re-enqueued for retry
+* `on_reject` - called when the job is rejected
+
+These callbacks do nothing by default but can be overridden. They are useful to execute recovery actions when a job fails (like sending an email to a customer for instance) or to report job status to external processes.
+
+The callbacks receive the body containing the payload of the job plus any error trace. They return `:ok`.
+
+#### Example
+
+```elixir
+defmodule FlakyJob do
+  use TaskBunny.Job
+  require Logger
+
+  def on_reject(_body) do
+     ...
+
+     :ok
+  end
+  ...
+end
+```
+
 
 ## Connection management
 

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -88,7 +88,28 @@ defmodule TaskBunny.Job do
   @callback perform(any) :: :ok | {:ok, any} | {:error, term}
 
   @doc """
-  Callback executed when a process gets rejected.
+  Callback executed when a job starts.
+
+  It receives the raw message structure including payload.
+  """
+  @callback on_start(any) :: :ok
+
+  @doc """
+  Callback executed when a job succeeds.
+
+  It receives the raw message structure including original payload.
+  """
+  @callback on_success(any) :: :ok
+
+  @doc """
+  Callback executed when a job gets requeued for retry.
+
+  It receives the raw message structure including original payload.
+  """
+  @callback on_retry(any) :: :ok
+
+  @doc """
+  Callback executed when a job gets rejected.
 
   It receives in input the whole error trace structure plus the orginal payload for inspection and recovery actions.
   """
@@ -163,10 +184,28 @@ defmodule TaskBunny.Job do
       def retry_interval(_failed_count), do: 300_000
 
       @doc false
+      @spec on_start(any) :: :ok
+      def on_start(_body), do: :ok
+
+      @doc false
+      @spec on_success(any) :: :ok
+      def on_success(_body), do: :ok
+
+      @doc false
+      @spec on_retry(any) :: :ok
+      def on_retry(_body), do: :ok
+
+      @doc false
       @spec on_reject(any) :: :ok
       def on_reject(_body), do: :ok
 
-      defoverridable timeout: 0, max_retry: 0, retry_interval: 1, on_reject: 1
+      defoverridable timeout: 0,
+                     max_retry: 0,
+                     retry_interval: 1,
+                     on_start: 1,
+                     on_success: 1,
+                     on_retry: 1,
+                     on_reject: 1
     end
   end
 

--- a/lib/task_bunny/job.ex
+++ b/lib/task_bunny/job.ex
@@ -223,6 +223,7 @@ defmodule TaskBunny.Job do
   - delay: Set time in milliseconds to schedule the job enqueue time.
   - host: RabbitMQ host. By default it is automatically selected from configuration.
   - queue: RabbitMQ queue. By default it is automatically selected from configuration.
+  - id: Set a job ID to enable unique identification of jobs, e.g. as an idempotency key.
 
   """
   @spec enqueue(atom, any, keyword) :: :ok | {:error, any}
@@ -240,7 +241,8 @@ defmodule TaskBunny.Job do
     queue_data = Config.queue_for_job(job) || []
 
     host = options[:host] || queue_data[:host] || :default
-    {:ok, message} = Message.encode(job, payload)
+    message_options = Keyword.take(options, [:id])
+    {:ok, message} = Message.encode(job, payload, message_options)
 
     case options[:queue] || queue_data[:name] do
       nil -> raise QueueNotFoundError, job: job

--- a/lib/task_bunny/message.ex
+++ b/lib/task_bunny/message.ex
@@ -14,27 +14,28 @@ defmodule TaskBunny.Message do
   @doc """
   Encode message body in JSON with job and argument.
   """
-  @spec encode(atom, any) :: {:ok, String.t()}
-  def encode(job, payload) do
-    data = message_data(job, payload)
+  @spec encode(atom, any, keyword | nil) :: {:ok, String.t()}
+  def encode(job, payload, options \\ []) do
+    data = message_data(job, payload, options)
     Poison.encode(data, pretty: true)
   end
 
   @doc """
   Similar to encode/2 but raises an exception on error.
   """
-  @spec encode!(atom, any) :: String.t()
-  def encode!(job, payload) do
-    data = message_data(job, payload)
+  @spec encode!(atom, any, keyword | nil) :: String.t()
+  def encode!(job, payload, options \\ []) do
+    data = message_data(job, payload, options)
     Poison.encode!(data, pretty: true)
   end
 
-  @spec message_data(atom, any) :: map
-  defp message_data(job, payload) do
+  @spec message_data(atom, any, keyword) :: map
+  defp message_data(job, payload, options) do
     %{
       "job" => encode_job(job),
       "payload" => payload,
-      "created_at" => DateTime.utc_now()
+      "created_at" => DateTime.utc_now(),
+      "id" => options[:id]
     }
   end
 

--- a/lib/task_bunny/worker.ex
+++ b/lib/task_bunny/worker.ex
@@ -149,7 +149,11 @@ defmodule TaskBunny.Worker do
       {:ok, decoded} ->
         Logger.debug(log_msg("basic_deliver", state, body: body))
 
-        JobRunner.invoke(decoded["job"], decoded["payload"], {body, meta})
+        job = decoded["job"]
+
+        start_callback(job, body)
+
+        JobRunner.invoke(job, decoded["payload"], {body, meta})
 
         {:noreply, %{state | runners: state.runners + 1}}
 
@@ -171,9 +175,7 @@ defmodule TaskBunny.Worker do
 
     case succeeded?(result) do
       true ->
-        Consumer.ack(state.channel, meta, true)
-
-        {:noreply, update_job_stats(state, :succeeded)}
+        handle_successful_job(state, body, meta)
 
       false ->
         handle_failed_job(state, body, meta, result)
@@ -223,6 +225,17 @@ defmodule TaskBunny.Worker do
   defp succeeded?({:ok, _}), do: true
   defp succeeded?(_), do: false
 
+  defp handle_successful_job(state, body, meta) do
+    {:ok, decoded} = Message.decode(body)
+    job = decoded["job"]
+
+    success_callback(job, body)
+
+    Consumer.ack(state.channel, meta, true)
+
+    {:noreply, update_job_stats(state, :succeeded)}
+  end
+
   defp handle_failed_job(state, body, meta, {:error, job_error}) do
     {:ok, decoded} = Message.decode(body)
     failed_count = Message.failed_count(decoded) + 1
@@ -249,6 +262,7 @@ defmodule TaskBunny.Worker do
       {:noreply, update_job_stats(state, :rejected)}
     else
       retry_message(job, state, new_body, meta, failed_count)
+      retry_callback(job, new_body)
       {:noreply, update_job_stats(state, :failed)}
     end
   end
@@ -279,6 +293,12 @@ defmodule TaskBunny.Worker do
     Consumer.ack(state.channel, meta, true)
     :ok
   end
+
+  defp start_callback(job, body), do: job.on_start(body)
+
+  defp success_callback(job, body), do: job.on_success(body)
+
+  defp retry_callback(job, body), do: job.on_retry(body)
 
   defp reject_callback(job, body), do: job.on_reject(body)
 

--- a/mix.lock
+++ b/mix.lock
@@ -21,5 +21,5 @@
   "rabbit_common": {:hex, :rabbit_common, "3.6.14", "dc134cd7228f656367e6e6ac88f1f4ef4a63d8a78a2238f52990a4de467708a1", [:make, :rebar3], [{:recon, "2.3.2", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm"},
   "recon": {:hex, :recon, "2.3.2", "4444c879be323b1b133eec5241cb84bd3821ea194c740d75617e106be4744318", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [], [], "hexpm"},
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [], [], "hexpm"}
 }

--- a/test/support/job_test_helper.ex
+++ b/test/support/job_test_helper.ex
@@ -24,16 +24,37 @@ defmodule TaskBunny.JobTestHelper do
 
     def retry_interval(_), do: RetryInterval.interval()
 
+    def on_start(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_start_callback_called)
+      :ok
+    end
+
+    def on_success(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_success_callback_called)
+      :ok
+    end
+
+    def on_retry(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_retry_callback_called)
+      :ok
+    end
+
     def on_reject(body) do
+      pid = enqueuer_pid(body)
+      pid && send(pid, :on_reject_callback_called)
+      :ok
+    end
+
+    defp enqueuer_pid(body) do
       ppid =
         body
         |> Poison.decode!()
         |> get_in(["payload", "ppid"])
 
-      ppid &&
-        ppid |> Base.decode64!() |> :erlang.binary_to_term() |> send(:on_reject_callback_called)
-
-      :ok
+      ppid && ppid |> Base.decode64!() |> :erlang.binary_to_term()
     end
   end
 

--- a/test/task_bunny/message_test.exs
+++ b/test/task_bunny/message_test.exs
@@ -10,8 +10,8 @@ defmodule TaskBunny.MessageTest do
 
   describe "encode/decode message body(payload)" do
     test "encode and decode payload" do
-      {:ok, encoded} = Message.encode(NameJob, %{"name" => "Joe"})
-      {:ok, %{"job" => job, "payload" => payload}} = Message.decode(encoded)
+      {:ok, encoded} = Message.encode(NameJob, %{"name" => "Joe"}, id: "some-id")
+      {:ok, %{"job" => job, "payload" => payload, "id" => "some-id"}} = Message.decode(encoded)
       assert job.perform(payload) == {:ok, "Joe"}
     end
 


### PR DESCRIPTION
## Changes

To satisfy the ability to track job execution state with a unique identifier, this PR introduces one new concept and expands on an existing paradigm.

### Optional Job `id`

Tracking job state in durable manner requires a job have a unique identifier. Given this is optional information about the job, it was determined this belongs with the rest of the job meta. To facilitate, `encode/2` and `encode!/2` have been expanded to include 3-arity variants taking `options`.

The only currently supported option is `id`, which is serialized onto the message body.

### Life-cycle Callbacks

Having the job id presented at different points in the job life-cycle allows for the developer to persist the current job state to a durable backend, such as Postgres or Redis. Job state can then be used to track execution, or restart the job at a given recovery point.

Following the pattern recently introduced by #61, we have expanded to include `on_start`, `on_success`, and `on_retry`. In like fashion, these callbacks do nothing by default, and only need to be implemented if desired.

Resolves https://github.com/shinyscorpion/task_bunny/issues/62