### PR TITLE
Allow disabling storing rejected jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,23 @@ The concurrency is set per an application.
 If you run your application on five different hosts with above configuration,
 there can be 55 jobs performing simultaneously in total.
 
+#### Disable storing rejected jobs in a queue
+
+By default, if a job fails more than `max_retry` times, the payload is sent to `[namespace].[job_name].rejected` queue.
+You can disable this behavior in the config by setting `store_rejected_jobs` worker parameter to `false` (defaults to `true`).
+This might be useful when rejected jobs queue is never consumed, thus making the queue grow infinitely.
+
+```elixir
+config :task_bunny, queue: [
+  namespace: "task_bunny."
+  queues: [
+    [name: "default", jobs: :default, worker: [concurrency: 1, store_rejected_jobs: false]]
+  ]
+]
+```
+
+With above, worker does not store rejected jobs. However, `on_reject` callback is still called when a job gets rejected.
+
 #### Disable worker
 
 You can disable workers starting with your application by setting `1`, `TRUE` or `YES` to `TASK_BUNNY_DISABLE_WORKER` environment variable.

--- a/lib/task_bunny/config.ex
+++ b/lib/task_bunny/config.ex
@@ -81,9 +81,17 @@ defmodule TaskBunny.Config do
           @default_concurrency
         end
 
+      store_rejected_jobs =
+        if queue[:worker] && is_boolean(queue[:worker][:store_rejected_jobs]) do
+          queue[:worker][:store_rejected_jobs]
+        else
+          true
+        end
+
       [
         queue: queue[:name],
         concurrency: concurrency,
+        store_rejected_jobs: store_rejected_jobs,
         host: queue[:host] || :default
       ]
     end)

--- a/test/task_bunny/config_test.exs
+++ b/test/task_bunny/config_test.exs
@@ -10,7 +10,8 @@ defmodule TaskBunny.ConfigTest do
           [name: "high", worker: [concurrency: 10], jobs: ["High.*"]],
           [name: "normal", jobs: :default],
           [name: "low", worker: false, jobs: [SlowJob]],
-          [name: "disabled", worker: [concurrency: 0], jobs: :default]
+          [name: "disabled", worker: [concurrency: 0], jobs: :default],
+          [name: "storing-rejected-disabled", worker: [store_rejected_jobs: false], jobs: :default]
         ]
       ],
       extra_queue: [
@@ -42,6 +43,7 @@ defmodule TaskBunny.ConfigTest do
                "test.normal",
                "test.low",
                "test.disabled",
+               "test.storing-rejected-disabled",
                "extra.queue1"
              ]
     end
@@ -50,9 +52,10 @@ defmodule TaskBunny.ConfigTest do
   describe "workers" do
     test "lists up information for workers" do
       assert Config.workers() == [
-               [queue: "test.high", concurrency: 10, host: :default],
-               [queue: "test.normal", concurrency: 2, host: :default],
-               [queue: "extra.queue1", concurrency: 1, host: :extra]
+               [queue: "test.high", concurrency: 10, store_rejected_jobs: true, host: :default],
+               [queue: "test.normal", concurrency: 2, store_rejected_jobs: true, host: :default],
+               [queue: "test.storing-rejected-disabled", concurrency: 2, store_rejected_jobs: false, host: :default],
+               [queue: "extra.queue1", concurrency: 1, store_rejected_jobs: true, host: :extra]
              ]
     end
   end


### PR DESCRIPTION
In some scenarios processing rejected jobs is not needed, meaning
sub-queue of rejected jobs is never consumed and it grows infinitely.
To fix this, add a configuration parameter which allows disabling
storing rejected jobs. The `on_reject` callback is still called
as it was before.